### PR TITLE
Adding back in the home and tags uSync content entries

### DIFF
--- a/SgfDevs/config/uSync8.config
+++ b/SgfDevs/config/uSync8.config
@@ -22,7 +22,7 @@
         <Handler Alias="templateHandler" Enabled="true" Actions="All" />
         <Handler Alias="contentTypeHandler" Enabled="true" Actions="All" />
         <Handler Alias="contentHandler" Enabled="true" Actions="All">
-          <Add Key="Include" Value="/Home/Groups,/Home/Companies,/Home/Events,/Tags/Skills,/Tags/Jobs,/Tags/Companies,/Tags/Members" />
+          <Add Key="Include" Value="/Home,/Tags,/Home/Groups,/Home/Companies,/Home/Events,/Tags/Skills,/Tags/Jobs,/Tags/Companies,/Tags/Members" />
           <Add Key="Exclude" Value="/Home/Groups/,/Home/Companies/,/Home/Events/,/Tags/Skills/,/Tags/Jobs/,/Tags/Companies/,/Tags/Members/" />
           <Add Key="RulesOnExport" Value="true" />
         </Handler>

--- a/SgfDevs/uSync/v8/Content/home.config
+++ b/SgfDevs/uSync/v8/Content/home.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="2504572c-2467-457c-990d-06aef735cb5d" Alias="Home" Level="1">
+  <Info>
+    <Parent Key="00000000-0000-0000-0000-000000000000"></Parent>
+    <Path>/Home</Path>
+    <Trashed>false</Trashed>
+    <ContentType>home</ContentType>
+    <CreateDate>2020-11-22T14:19:00</CreateDate>
+    <NodeName Default="Home" />
+    <SortOrder>0</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template Key="f94a56f8-f31e-46fb-a526-f353d39f171f">Home</Template>
+  </Info>
+  <Properties />
+</Content>

--- a/SgfDevs/uSync/v8/Content/tags.config
+++ b/SgfDevs/uSync/v8/Content/tags.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="235713a3-e988-42ce-bc14-513fd8790416" Alias="Tags" Level="1">
+  <Info>
+    <Parent Key="00000000-0000-0000-0000-000000000000"></Parent>
+    <Path>/Tags</Path>
+    <Trashed>false</Trashed>
+    <ContentType>tags</ContentType>
+    <CreateDate>2020-11-22T19:07:12</CreateDate>
+    <NodeName Default="Tags" />
+    <SortOrder>2</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template />
+  </Info>
+  <Properties />
+</Content>


### PR DESCRIPTION
These somehow got removed across a couple of commits and resulted in the uSync content import breaking since they are root level nodes that all of the other content nodes depend on.