### PR TITLE
chore(deps): update .NET packages

### DIFF
--- a/SgfDevs.Tests/appsettings-schema.Umbraco.Cms.json
+++ b/SgfDevs.Tests/appsettings-schema.Umbraco.Cms.json
@@ -111,6 +111,9 @@
         "DistributedJobSettings": {
           "$ref": "#/definitions/DistributedJobSettings"
         },
+        "ScheduledPublishing": {
+          "$ref": "#/definitions/ScheduledPublishingSettings"
+        },
         "Website": {
           "$ref": "#/definitions/WebsiteSettings"
         },
@@ -142,6 +145,11 @@
         "ResolveUrlsFromTextString": {
           "type": "boolean",
           "description": "Gets or sets a value indicating whether URLs should be resolved from text strings.\n            ",
+          "default": false
+        },
+        "SortChildrenByFieldFiresNotifications": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether sorting the children of a node by a field fires\nper-item save/sort notifications (and therefore webhooks).\n            ",
           "default": false
         },
         "Error404Collection": {
@@ -848,6 +856,12 @@
           "description": "Gets or sets a value for the time span to wait before considering a server stale, after it has last been accessed.\n            ",
           "format": "duration",
           "default": "00:02:00"
+        },
+        "TouchTimeout": {
+          "type": "string",
+          "description": "Gets or sets the maximum time to wait for a single server touch operation to complete before it is\nconsidered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring\njob keeps running rather than stopping permanently. This bounds how long the job waits on a single touch,\nnot how long a stalled connection itself takes to recover (which is governed by the database timeouts).\n            ",
+          "format": "duration",
+          "default": "00:01:00"
         }
       }
     },
@@ -876,6 +890,12 @@
         "TimeBetweenPruneOperations": {
           "type": "string",
           "description": "Gets or sets a value for the time to wait between each prune operations.\n            ",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "SyncTimeout": {
+          "type": "string",
+          "description": "Gets or sets the maximum time to wait for a single synchronization operation to complete before it is\nconsidered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring\njob keeps running rather than stopping permanently. This bounds how long the job waits on a single sync,\nnot how long a stalled connection itself takes to recover (which is governed by the database timeouts).\n            ",
           "format": "duration",
           "default": "00:01:00"
         }
@@ -1146,6 +1166,13 @@
             "string"
           ],
           "description": "Gets or sets a value specifying the name of the site.\n            "
+        },
+        "MachineIdentifier": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a stable identifier for this server instance used to track cache synchronization state.\n            "
         }
       }
     },
@@ -1281,7 +1308,8 @@
         "BatchSize": {
           "type": "integer",
           "description": "Gets or sets a value for how many items to index at a time.",
-          "format": "int32"
+          "format": "int32",
+          "default": 10000
         }
       }
     },
@@ -1309,8 +1337,31 @@
           "type": "string",
           "description": "Gets or sets the file name format arguments to use for log files.",
           "default": "MachineName"
+        },
+        "SessionIdLogging": {
+          "description": "Gets or sets a value determining how log events are enriched with a session identifier.",
+          "default": "SessionId",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SessionIdLoggingMode"
+            }
+          ]
         }
       }
+    },
+    "SessionIdLoggingMode": {
+      "type": "string",
+      "description": "Determines how request logging enriches log events with a session identifier.",
+      "x-enumNames": [
+        "None",
+        "SessionId",
+        "CookieHash"
+      ],
+      "enum": [
+        "None",
+        "SessionId",
+        "CookieHash"
+      ]
     },
     "NuCacheSettings": {
       "type": "object",
@@ -1335,6 +1386,12 @@
           "type": "boolean",
           "description": "Gets or sets a value indicating whether to use paged SQL queries for nucache.\n            ",
           "default": true
+        },
+        "ContentTypeRebuildDeleteBatchSize": {
+          "type": "integer",
+          "description": "Gets or sets the number of content items whose stale NuCache rows are deleted per batch during a\ncontent type structural rebuild.\n            ",
+          "format": "int32",
+          "default": 2000
         }
       }
     },
@@ -1818,6 +1875,11 @@
       "type": "object",
       "description": "Typed configuration options for the plugins.\n            ",
       "properties": {
+        "Cachebuster": {
+          "type": "string",
+          "description": "Gets or sets an optional host-controlled cache-buster for package /App_Plugins assets. When set (e.g.\nto a build number or deployment id), it is appended as umb__rnd to every package's assets — importmap\nand extensions — forcing a re-fetch regardless of each package's own version. Empty by default (no effect).\n            ",
+          "default": ""
+        },
         "BrowsableFileExtensions": {
           "type": "array",
           "description": "Gets or sets the allowed file extensions (including the period \".\") that should be accessible from the browser.\n            ",
@@ -2282,6 +2344,14 @@
           "description": "Gets or sets the duration that items remain in the seed cache.\n            ",
           "format": "duration",
           "default": "365.00:00:00"
+        },
+        "MaximumLocalCacheItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gets or sets the maximum number of converted items kept in the in-process (L0) published-content\ncache, or null for no limit.\n            ",
+          "format": "int32"
         }
       }
     },
@@ -2306,6 +2376,23 @@
           "description": "Gets or sets the maximum execution time for a distributed job before it is considered timed out.\nWhen a job exceeds this time, it is considered stale and can be picked up by another server for recovery and restarted.\n            ",
           "format": "duration",
           "default": "00:05:00"
+        }
+      }
+    },
+    "ScheduledPublishingSettings": {
+      "type": "object",
+      "description": "Settings for scheduled publishing.",
+      "properties": {
+        "Period": {
+          "type": "string",
+          "description": "Gets or sets a value for how often scheduled publishing runs.",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "AlignToClock": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether scheduled publishing runs are aligned to clock boundaries\nderived from Period (for example, on the minute, or every N seconds), rather than drifting\nbased on when the previous run completed.",
+          "default": false
         }
       }
     },

--- a/SgfDevs.Tests/umbraco-package-schema.json
+++ b/SgfDevs.Tests/umbraco-package-schema.json
@@ -1,8 +1,16843 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "(ManifestUfmFilter|ManifestUfmComponent|ManifestMarkedExtension|ManifestPropertyValueCloner|UmbPropertyEditorExtensions|ManifestPropertyValuePreset|ManifestPropertyValueResolver|ManifestEntityActionDuplicateToKind|ManifestEntityActionMoveToKind|ManifestEntityActionReloadTreeItemChildrenKind|ManifestEntityActionSortChildrenOfKind|UmbSectionExtensions|ManifestDashboard|ManifestWorkspaceDefaultKind|ManifestWorkspaceActionDefaultKind|ManifestWorkspaceFooterApp|ManifestWorkspaceFooterAppMenuBreadcrumbKind|ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind|ManifestWorkspaceViewContentTypeDesignEditorKind|ManifestWorkspaceView<MetaWorkspaceView>|ManifestWorkspaceRoutableKind|ManifestWorkspaceContext|ManifestTreeItem|ManifestTree|ManifestEntityActionCreateFolderKind|ManifestEntityActionDeleteFolderKind|ManifestEntityActionUpdateFolderKind|ManifestEntityCreateOptionActionFolderKind|ManifestMenu|ManifestMenuItem|ManifestMenuItemActionKind|ManifestMenuItemLinkKind|ManifestWorkspaceContextMenuStructureKind|ManifestMenuItemTreeKind|ManifestModal|ManifestCollectionAction|ManifestCollection|ManifestCollectionActionCreateKind|ManifestCollectionTextFilter|ManifestCollectionMenu|ManifestCollectionView|ManifestCollectionViewTableKind|ManifestWorkspaceViewCollectionKind|ManifestValueSummary|ManifestAuditLogActionDefaultKind|ManifestEntityActionContentRollbackKind|ManifestWorkspaceInfoAppAuditLogKind|ManifestWorkspaceViewContentCollectionKind|ManifestEntityActionSortChildrenOfContentKind|ManifestUserProfileApp|ManifestAuthProvider|ManifestIcons|ManifestEntityUserPermission|ManifestGranularUserPermission|ManifestLocalization|ManifestPickerSearchResultItem|ManifestCollectionMenuItem|ManifestPropertyEditorDataSource|ManifestEntityActionDeleteKind|ManifestEntityActionDefaultKind|ManifestEntityActionCreateKind|ManifestSearchProvider|ManifestSearchResultItem|ManifestGlobalSearch|ManifestAppEntryPoint|ManifestBackofficeEntryPoint|ManifestEntryPoint|UmbCoreManifestTypes|ManifestEntityItemRef<MetaEntityItemRef>|ManifestDataSourceDataMapping<MetaDataSourceDataMapping>|ManifestPropertyContext<MetaPropertyContext>|ManifestSectionContext<MetaSectionContext>|ManifestWorkspaceActionMenuItem<MetaWorkspaceActionMenuItem>|ManifestWorkspaceActionMenuItemDefaultKind<MetaWorkspaceActionMenuItemDefaultKind>|ManifestWorkspaceInfoApp<MetaWorkspaceInfoApp>|ManifestWorkspaceAction<MetaWorkspaceAction,UmbWorkspaceAction<MetaWorkspaceAction>>|ManifestWorkspace<MetaWorkspace,UmbControllerHostElement,UmbWorkspaceContext>|ManifestEntityCreateOptionAction<MetaEntityCreateOptionAction>|ManifestEntityCollectionItemCard<MetaEntityCollectionItemCard>|ManifestEntityCollectionItemRef<MetaEntityCollectionItemRef>|ManifestAuditLogAction<MetaAuditLogAction>|ManifestCurrentUserAction<MetaCurrentUserAction>|ManifestPropertyValidationPathTranslator<any>|ManifestEntityAction<MetaEntityAction>|ManifestEntityBulkActionDeleteKind|UmbEntityBulkActionExtensions|ManifestExternalLoginProvider|ManifestGlobalContext|ManifestHeaderApp|ManifestHeaderAppButtonKind|ManifestMfaLoginProvider|ManifestPreviewAppProvider|ManifestRepository<UmbApi>|UmbStoreExtensions)[]": {
+        "CollectionAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.CollectionAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "The collection that this extension should be available in",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "DelayConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Delay%22%3E"
+                },
+                {
+                    "properties": {
+                        "offset": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "offset"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "ManifestAppEntryPoint": {
+            "description": "Manifest for an `appEntryPoint`, which is loaded up front when the app starts.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.\nThis is useful for extensions that need to be loaded up front, like an `authProvider`.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "appEntryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
             "type": "object"
+        },
+        "ManifestAuditLogAction<MetaAuditLogAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuditLogAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "auditLogAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestAuditLogActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuditLogActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "auditLogAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestAuthProvider": {
+            "description": "Represents an authentication provider that can be used to authenticate users.\nThe provider needs to be registered in the API that the authorization request is sent to in order to be used.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forProviderName": {
+                    "description": "The provider name that this provider is for.",
+                    "examples": "'Umbraco.Github'",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuthProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "authProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forProviderName",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBackofficeEntryPoint": {
+            "description": "Manifest for an `backofficeEntryPoint`, which is loaded after the Backoffice has been loaded and authentication has been done.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "backofficeEntryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBase": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBundle<UmbCoreManifestTypes>": {
+            "description": "This type of extension takes a JS module and registers all exported manifests from the pointed JS file.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "bundle",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollection": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollection"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collection",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionAction": {
+            "description": "An action to perform on an entity\nFor example for content you may wish to create a new document etc",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionMenu": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionMenu"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "collectionMenu",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionMenuItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "collectionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionTextFilter": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionTextFilter",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionViewTableKind": {
+            "description": "Manifest type for the `table` kind of `collectionView`.\nAllows registering a table collection view with custom columns via manifest meta.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "table",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionViewTableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCondition": {
+            "description": "This type of extension takes a JS module and registers all exported manifests from the pointed JS file.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "condition",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCurrentUserAction<MetaCurrentUserAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCurrentUserAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "currentUserAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestDashboard": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaDashboard",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "dashboard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestDataSourceDataMapping<MetaDataSourceDataMapping>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forDataModel": {
+                    "type": "string"
+                },
+                "forDataSource": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaDataSourceDataMapping"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "dataSourceDataMapping",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forDataModel",
+                "forDataSource",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityAction<MetaEntityAction>": {
+            "description": "An action to perform on an entity\nFor example for content you may wish to create a new document etc",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentPublishKind": {
+            "description": "Manifest for an entity action registered against the shared `contentPublish` kind.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentPublish",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentPublishKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentRollbackKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentRollback",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentRollbackKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentUnpublishKind": {
+            "description": "Manifest for an entity action registered against the shared `contentUnpublish` kind.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentUnpublish",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentUnpublishKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionCreateFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderCreate",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionCreateKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDeleteFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderDelete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDeleteKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "delete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDeleteKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "duplicateTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDuplicateToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionMoveToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "moveTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionMoveToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionReloadTreeItemChildrenKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "reloadTreeItemChildren",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionReloadTreeItemChildrenKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionSortChildrenOfContentKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "sortChildrenOfContent",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionSortChildrenOfContentKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionSortChildrenOfKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "sortChildrenOf",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionSortChildrenOfKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionUpdateFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderUpdate",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkAction<MetaEntityBulkAction>": {
+            "description": "An action to perform on multiple entities\nFor example for content you may wish to move one or more documents in bulk",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDefaultKind<MetaEntityBulkActionDefaultKind>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDeleteKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "delete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDeleteKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "duplicateTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDuplicateToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionMoveToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "moveTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionMoveToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionTrashKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "trash",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionTrashKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCollectionItemCard<MetaEntityCollectionItemCard>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "description": "The entity types this collection item supports.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCollectionItemCard",
+                    "description": "Additional metadata for the collection item."
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCollectionItemCard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCollectionItemRef<MetaEntityCollectionItemRef>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "description": "The entity types this collection item supports.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCollectionItemRef",
+                    "description": "Additional metadata for the collection item."
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCollectionItemRef",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCreateOptionAction<MetaEntityCreateOptionAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCreateOptionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCreateOptionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCreateOptionActionFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folder",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCreateOptionActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCreateOptionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityItemRef<MetaEntityItemRef>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityItemRef",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityItemRef",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityUserPermission": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityUserPermission"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entityUserPermission",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntryPoint": {
+            "description": "Manifest for an `entryPoint`, which is loaded after the Backoffice has been loaded and authentication has been done.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestExternalLoginProvider": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaExternalLoginProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "externalLoginProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGlobalContext": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "globalContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGlobalSearch": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaGlobalSearch"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "globalSearch",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGranularUserPermission": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaGranularUserPermission",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "userGranularPermission",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestHeaderApp": {
+            "description": "Header apps are displayed in the top right corner of the backoffice\nThe two provided header apps are the search and the user menu",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "headerApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestHeaderAppButtonKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "button",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaHeaderAppButtonKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "headerApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestIcons": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "icons",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestItemStore": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "itemStore",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestLocalization": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaLocalization"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "localization",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMarkedExtension": {
+            "description": "The `markedExtension` extension-type is currently for internal use and should be considered experimental.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMarkedExtension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "markedExtension",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenu": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "menu",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItem",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemActionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "action",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemActionKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemLinkKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "link",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemLinkKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemTreeKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "tree",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemTreeKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMfaLoginProvider": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forProviderName": {
+                    "description": "The provider names that this provider is for.",
+                    "examples": "'Umbraco.GoogleAuthenticator'",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMfaLoginProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "mfaLoginProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forProviderName",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestModal": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "modal",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPickerSearchResultItem": {
+            "description": "Represents a picker search result element.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "pickerSearchResultItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPreviewAppProvider": {
+            "description": "Preview apps are displayed in the menu of the preview window.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "previewApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyContext<MetaPropertyContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forPropertyEditorUis": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyContext"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "propertyContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forPropertyEditorUis",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorDataSource": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "dataSourceType": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorDataSource"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorDataSource",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "dataSourceType",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorSchema": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorSchema"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorSchema",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorUi": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorUi",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorUi",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValidationPathTranslator<any>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValidationPathTranslator",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValueCloner": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValueCloner",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValuePreset": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forPropertyEditorSchemaAlias": {
+                    "type": "string"
+                },
+                "forPropertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValuePreset",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValueResolver": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyValueResolver"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValueResolver",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestRepository<UmbApi>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "repository",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSearchProvider": {
+            "description": "Represents an search provider that can be used to search.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSearchProvider"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "searchProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSearchResultItem": {
+            "description": "Represents a search result element.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "searchResultItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSection": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSection"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "section",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionContext<MetaSectionContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionContext"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionRoute": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionRoute"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "sectionRoute",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionSidebarApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionSidebarApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestStore": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "store",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTree": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTree"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "tree",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeAction": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "treeItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeItemCard": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "treeItemCard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forTrees": {
+                    "description": "The tree aliases this view applies to. When omitted, the view applies to all trees.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeViewTableKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forTrees": {
+                    "description": "The tree aliases this view applies to. When omitted, the view applies to all trees.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "table",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeViewTableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUfmComponent": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUfmComponent"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ufmComponent",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUfmFilter": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUfmFilter"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ufmFilter",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUserProfileApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUserProfileApp",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "userProfileApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestValueSummary": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forValueType": {
+                    "description": "The value type this summary is registered for.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaValueSummary"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "valueSummary",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "valueResolver": {
+                    "description": "Optional resolver for batch-resolving raw values before rendering.\nUsed by the coordinator for efficient batching across multiple elements.",
+                    "type": "object"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forValueType",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspace<MetaWorkspace,UmbControllerHostElement,UmbWorkspaceContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspace"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceAction<MetaWorkspaceAction,UmbWorkspaceAction<MetaWorkspaceAction>>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionMenuItem<MetaWorkspaceActionMenuItem>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forWorkspaceActions": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define which workspace actions this menu item should be shown for.",
+                    "examples": "[\r\n['Umb.WorkspaceAction.Document.Save', 'Umb.WorkspaceAction.Document.SaveAndPublish'],\r\n\"Umb.WorkspaceAction.Document.Save\"\r\n]"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionMenuItem"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceActionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forWorkspaceActions",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionMenuItemDefaultKind<MetaWorkspaceActionMenuItemDefaultKind>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forWorkspaceActions": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define which workspace actions this menu item should be shown for.",
+                    "examples": "[\r\n['Umb.WorkspaceAction.Document.Save', 'Umb.WorkspaceAction.Document.SaveAndPublish'],\r\n\"Umb.WorkspaceAction.Document.Save\"\r\n]"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionMenuItemDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceActionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forWorkspaceActions",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceContext": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceContextMenuStructureKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "menuStructure",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceContextMenuStructureKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterAppMenuBreadcrumbKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "menuBreadcrumb",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "variantMenuBreadcrumb",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceInfoApp<MetaWorkspaceInfoApp>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceInfoApp",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceInfoApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceInfoAppAuditLogKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "auditLog",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceInfoAppAuditLogKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceInfoApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceRoutableKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "routable",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceRoutableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceView<MetaWorkspaceView>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewCollectionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "collection",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewCollectionKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewContentCollectionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentCollection",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewContentTypeDesignEditorKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentTypeDesignEditor",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewContentTypeDesignEditorKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewTreeKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "tree",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewTreeKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "MetaAuditLogAction": {
+            "type": "object"
+        },
+        "MetaAuditLogActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaAuthProvider": {
+            "properties": {
+                "behavior": {
+                    "description": "The behavior of the provider when it is used.",
+                    "properties": {
+                        "autoRedirect": {
+                            "default": false,
+                            "description": "If true, the user will be redirected to the provider's login page immediately.",
+                            "type": "boolean"
+                        },
+                        "popupFeatures": {
+                            "default": "'width=600,height=600,menubar=no,location=no,resizable=yes,scrollbars=yes,status=no,toolbar=no'",
+                            "description": "The features of the popup that is opened when the user logs in.",
+                            "type": "string"
+                        },
+                        "popupTarget": {
+                            "default": "'umbracoAuthPopup'",
+                            "description": "The target of the popup that is opened when the user logs in.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "defaultView": {
+                    "description": "The default view of the provider that is shown to the user.\nIf no element is provided, then the button will be rendered as a",
+                    "properties": {
+                        "color": {
+                            "default": "'secondary'",
+                            "description": "The color of the provider that is shown to the user.",
+                            "enum": [
+                                "",
+                                "danger",
+                                "default",
+                                "invalid",
+                                "positive",
+                                "warning"
+                            ],
+                            "type": "string"
+                        },
+                        "icon": {
+                            "default": "'icon-cloud'",
+                            "description": "The icon of the provider that is shown to the user.",
+                            "examples": "['icon-cloud', 'icon-github', 'icon-google', 'icon-facebook', 'icon-twitter', 'icon-x', 'icon-microsoft']",
+                            "type": "string"
+                        },
+                        "look": {
+                            "default": "'default'",
+                            "description": "The look of the provider that is shown to the user.",
+                            "enum": [
+                                "",
+                                "default",
+                                "outline",
+                                "placeholder",
+                                "primary",
+                                "secondary"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "label": {
+                    "description": "The label of the provider that is shown to the user.",
+                    "type": "string"
+                },
+                "linking": {
+                    "description": "The linking options of the provider when it is used.",
+                    "properties": {
+                        "allowManualLinking": {
+                            "default": false,
+                            "description": "If true, the user will be able to link the provider to an existing account.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MetaCollection": {
+            "properties": {
+                "noItemsLabel": {
+                    "type": "string"
+                },
+                "repositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "repositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionAction": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionMenu": {
+            "properties": {
+                "collectionRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionView": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the collection view",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the collection view",
+                    "type": "string"
+                },
+                "pathName": {
+                    "description": "The URL pathname for this collection view that can be deep linked to by sharing the url",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathName"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionViewTableKind": {
+            "description": "Meta configuration for the `table` kind of `collectionView`.",
+            "properties": {
+                "columns": {
+                    "description": "Additional columns to render between the name and entity actions columns.",
+                    "items": {
+                        "$ref": "#/definitions/MetaCollectionViewTableKindColumn"
+                    },
+                    "type": "array"
+                },
+                "icon": {
+                    "description": "An icon to represent the collection view",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the collection view",
+                    "type": "string"
+                },
+                "pathName": {
+                    "description": "The URL pathname for this collection view that can be deep linked to by sharing the url",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaCollectionViewTableKindColumn": {
+            "description": "Configuration for a single column in a table collection view kind.",
+            "properties": {
+                "field": {
+                    "description": "The property name on the collection item model to display in this column.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The column header label. Supports localization strings (e.g. `#general_status`).",
+                    "type": "string"
+                },
+                "valueType": {
+                    "description": "Optional value type for rendering a value summary in this column.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "field",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaCurrentUserAction": {
+            "type": "object"
+        },
+        "MetaDashboard": {
+            "properties": {
+                "label": {
+                    "description": "The displayed name (label) in the navigation.",
+                    "type": "string"
+                },
+                "pathname": {
+                    "description": "This is the URL path part for this view. This is used for navigating or deep linking directly to the dashboard\nhttps://yoursite.com/section/settings/dashboard/my-dashboard-path",
+                    "examples": [
+                        "my-dashboard-path"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaDataSourceDataMapping": {
+            "type": "object"
+        },
+        "MetaEntityAction": {
+            "type": "object"
+        },
+        "MetaEntityActionContentPublishKind": {
+            "description": "Meta configuration for the `contentPublish` entity action kind.",
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "detailRepositoryAlias": {
+                    "description": "Alias of the detail repository used to load the content item.",
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "publishedNotificationMessage": {
+                    "description": "Overrides the success notification message when invariant content is published.\nUse a localization key, e.g. `#speechBubbles_editContentPublishedText`.",
+                    "type": "string"
+                },
+                "publishingRepositoryAlias": {
+                    "description": "Alias of the publishing repository used to perform the publish operation.",
+                    "type": "string"
+                },
+                "variantPublishedNotificationMessage": {
+                    "description": "Overrides the success notification message when one or more variants are published.\nUse a localization key, e.g. `#speechBubbles_editVariantPublishedText` — the list of published variants\nis passed as the first term argument, so a plain (non-key) string will not include it.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "label",
+                "publishingRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionContentRollbackKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "rollbackNotificationMessage": {
+                    "type": "string"
+                },
+                "rollbackRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "label",
+                "rollbackRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionContentUnpublishKind": {
+            "description": "Meta configuration for the `contentUnpublish` entity action kind.",
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "configurationRepositoryAlias": {
+                    "description": "Alias of the configuration repository used by the modal to read unpublish behaviour configuration.",
+                    "type": "string"
+                },
+                "detailRepositoryAlias": {
+                    "description": "Alias of the detail repository used to load the content item.",
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "description": "Alias of the item repository used by the modal to present the affected items.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "publishingRepositoryAlias": {
+                    "description": "Alias of the publishing repository used to perform the unpublish operation.",
+                    "type": "string"
+                },
+                "referenceRepositoryAlias": {
+                    "description": "Alias of the reference repository used by the modal to warn about inbound references.",
+                    "type": "string"
+                },
+                "unpublishedNotificationMessage": {
+                    "description": "Overrides the success notification message when content is unpublished.\nUse a localization key, e.g. `#speechBubbles_contentUnpublished`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "configurationRepositoryAlias",
+                "detailRepositoryAlias",
+                "icon",
+                "itemRepositoryAlias",
+                "label",
+                "publishingRepositoryAlias",
+                "referenceRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionCreateKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDeleteKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "confirm": {
+                    "properties": {
+                        "headline": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "itemRepositoryAlias",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDuplicateToKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "duplicateRepositoryAlias": {
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "duplicateRepositoryAlias",
+                "icon",
+                "label",
+                "treeAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionFolderKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "folderRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "folderRepositoryAlias",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionMoveToKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "moveRepositoryAlias": {
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "moveRepositoryAlias",
+                "treeAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionReloadTreeItemChildrenKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionSortChildrenOfContentKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemDataResolver": {
+                    "$ref": "#/definitions/UmbItemDataResolverConstructor%3CUmbItemModel%3E"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "sortChildrenOfRepositoryAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "sortChildrenOfRepositoryAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionSortChildrenOfKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "sortChildrenOfRepositoryAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "sortChildrenOfRepositoryAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkAction": {
+            "type": "object"
+        },
+        "MetaEntityBulkActionDefaultKind": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaEntityBulkActionDeleteKind": {
+            "properties": {
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "itemRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "bulkDuplicateRepositoryAlias": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "bulkDuplicateRepositoryAlias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "treeAlias",
+                "type"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionMoveToKind": {
+            "properties": {
+                "bulkMoveRepositoryAlias": {
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bulkMoveRepositoryAlias",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionTrashKind": {
+            "properties": {
+                "bulkTrashRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bulkTrashRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityCollectionItemCard": {
+            "type": "object"
+        },
+        "MetaEntityCollectionItemRef": {
+            "type": "object"
+        },
+        "MetaEntityCreateOptionAction": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "description": {
+                    "description": "A description of the action to be performed",
+                    "examples": [
+                        "Create a document type with a template",
+                        "Create a document from a blueprint"
+                    ],
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create with Template",
+                        "Create from Blueprint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityCreateOptionActionFolderKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "description": {
+                    "description": "A description of the action to be performed",
+                    "examples": [
+                        "Create a document type with a template",
+                        "Create a document from a blueprint"
+                    ],
+                    "type": "string"
+                },
+                "folderRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create with Template",
+                        "Create from Blueprint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "folderRepositoryAlias",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityItemRef": {
+            "type": "object"
+        },
+        "MetaEntityUserPermission": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "verbs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "verbs"
+            ],
+            "type": "object"
+        },
+        "MetaExternalLoginProvider": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaGlobalSearch": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "type": "string"
+                },
+                "sectionAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "searchProviderAlias"
+            ],
+            "type": "object"
+        },
+        "MetaGranularUserPermission": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "descriptionKey": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "labelKey": {
+                    "type": "string"
+                },
+                "schemaType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "schemaType"
+            ],
+            "type": "object"
+        },
+        "MetaHeaderAppButtonKind": {
+            "properties": {
+                "href": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "href",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaLocalization": {
+            "properties": {
+                "culture": {
+                    "description": "The culture is a combination of a language and a country. The language is represented by an ISO 639-1 code and the country is represented by an ISO 3166-1 alpha-2 code.\r\nThe language and country are separated by a dash.\r\nThe value is used to describe the language of the translations according to the extension system\r\nand it will be set as the `lang` attribute on the `<html>` element.",
+                    "type": "string"
+                },
+                "direction": {
+                    "default": "ltr",
+                    "description": "The value is used to describe the direction of the translations according to the extension system\r\nand it will be set as the `dir` attribute on the `<html>` element. It defaults to `ltr`.",
+                    "enum": [
+                        "ltr",
+                        "rtl"
+                    ],
+                    "type": "string"
+                },
+                "localizations": {
+                    "$ref": "#/definitions/UmbLocalizationDictionary",
+                    "description": "The localizations."
+                }
+            },
+            "required": [
+                "culture"
+            ],
+            "type": "object"
+        },
+        "MetaMarkedExtension": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItem": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemActionKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemLinkKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "href",
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemTreeKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "menus",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "MetaMfaLoginProvider": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaPropertyContext": {
+            "type": "object"
+        },
+        "MetaPropertyEditorDataSource": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyEditorSchema": {
+            "properties": {
+                "defaultPropertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                }
+            },
+            "required": [
+                "defaultPropertyEditorUiAlias"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyEditorUi": {
+            "properties": {
+                "group": {
+                    "default": "Common",
+                    "description": "The group that this property editor UI belongs to, which will be used to group\nthe property editor UIs in the property editor picker.\nIf not specified, the property editor UI will be grouped under \"Common\".\n\nCore property editors use localization keys prefixed with `#` (e.g. `\"#propertyEditorUIGroups_common\"`).\nExternal packages can use either display-ready names (e.g. `\"My Group\"`) or camelCase names\n(e.g. `\"myGroup\"`) which will be automatically converted to title case.",
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "description": "A list of keywords that can be used to search for this property editor UI in the property editor picker.\nIf not specified, the property editor UI will not have any keywords.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "propertyEditorSchemaAlias": {
+                    "description": "The alias of the property editor schema that this property editor UI is for.\nIf not specified, the property editor UI can only be used to configure other property editors.",
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                },
+                "supportsDataSource": {
+                    "properties": {
+                        "enabled": {
+                            "description": "Whether the property editor UI is enabled for use with data sources.",
+                            "type": "{boolean}"
+                        },
+                        "forDataSourceTypes": {
+                            "description": "A list of allowed property editor data source kinds that can be used with this property editor UI.\nIf not specified, any data sources can be used.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "enabled",
+                        "forDataSourceTypes"
+                    ],
+                    "type": "object"
+                },
+                "supportsReadOnly": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "group",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyValueResolver": {
+            "type": "object"
+        },
+        "MetaSearchProvider": {
+            "properties": {
+                "label": {
+                    "description": "The label of the provider that is shown to the user.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaSection": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                },
+                "preventUrlRetention": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaSectionContext": {
+            "type": "object"
+        },
+        "MetaSectionRoute": {
+            "properties": {
+                "path": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaSectionView": {
+            "properties": {
+                "icon": {
+                    "description": "The icon displayed for this view in the navigation.",
+                    "examples": [
+                        "box"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The displayed name (label) in the navigation.",
+                    "type": "string"
+                },
+                "pathname": {
+                    "description": "This is the URL path part for this view. This is used for navigating or deep linking directly to the view\nhttps://yoursite.com/section/settings/view/my-view-path",
+                    "examples": [
+                        "my-view-path"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon"
+            ],
+            "type": "object"
+        },
+        "MetaTree": {
+            "properties": {
+                "repositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "repositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaTreeAction": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaTreeView": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the tree view",
+                    "examples": [
+                        "icon-list",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the tree view",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaTreeViewTableKind": {
+            "properties": {
+                "columns": {
+                    "description": "Additional columns to render between the name and entity actions columns.",
+                    "items": {
+                        "$ref": "#/definitions/MetaTreeViewTableKindColumn"
+                    },
+                    "type": "array"
+                },
+                "icon": {
+                    "description": "An icon to represent the tree view",
+                    "examples": [
+                        "icon-list",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the tree view",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaTreeViewTableKindColumn": {
+            "properties": {
+                "field": {
+                    "description": "The property name on the tree item model to display in this column.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The column header label. Supports localization strings (e.g. `#general_status`).",
+                    "type": "string"
+                },
+                "valueType": {
+                    "description": "Optional value type for rendering a value summary in this column.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "field",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaUfmComponent": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "marker": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaUfmFilter": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaUserProfileApp": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaValueSummary": {
+            "type": "object"
+        },
+        "MetaWorkspace": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceAction": {
+            "type": "object"
+        },
+        "MetaWorkspaceActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "color": {
+                    "enum": [
+                        "",
+                        "danger",
+                        "default",
+                        "invalid",
+                        "positive",
+                        "warning"
+                    ],
+                    "type": "string"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "look": {
+                    "enum": [
+                        "",
+                        "default",
+                        "outline",
+                        "placeholder",
+                        "primary",
+                        "secondary"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaWorkspaceActionMenuItem": {
+            "type": "object"
+        },
+        "MetaWorkspaceActionMenuItemDefaultKind": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceContextMenuStructureKind": {
+            "properties": {
+                "menuItemAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "menuItemAlias"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceDefaultKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType",
+                "headline"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceInfoApp": {
+            "type": "object"
+        },
+        "MetaWorkspaceInfoAppAuditLogKind": {
+            "properties": {
+                "auditLogRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "auditLogRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceRoutableKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceView": {
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewCollectionKind": {
+            "properties": {
+                "collectionAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionAlias",
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewContentTypeDesignEditorKind": {
+            "properties": {
+                "compositionRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewTreeKind": {
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettings": {
+            "properties": {
+                "defaultData": {
+                    "items": {
+                        "$ref": "#/definitions/PropertyEditorSettingsDefaultData"
+                    },
+                    "type": "array"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/PropertyEditorSettingsProperty"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "properties"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettingsDefaultData": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "value": {}
+            },
+            "required": [
+                "alias",
+                "value"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettingsProperty": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "config": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "value": {}
+                        },
+                        "required": [
+                            "alias"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "propertyEditorDataSourceAlias": {
+                    "type": "string"
+                },
+                "propertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "validation": {
+                    "properties": {
+                        "mandatory": {
+                            "type": "boolean"
+                        },
+                        "mandatoryMessage": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "mandatory"
+                    ],
+                    "type": "object"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "label",
+                "propertyEditorUiAlias"
+            ],
+            "type": "object"
+        },
+        "SectionAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.SectionAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the section that this extension should be available in",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more workspaces that this extension should be available in",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "SwitchConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Switch%22%3E"
+                },
+                {
+                    "properties": {
+                        "frequency": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "frequency"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "TreeAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.TreeAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "The tree that this extension should be available in.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbCollectionHasItemsConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CollectionHasItems",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.CollectionAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CollectionAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Delay\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Delay",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Entity.Type\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Entity.Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Entity.Unique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Entity.Unique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.EntityContentType.Unique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.EntityContentType.Unique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.SectionAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.SectionAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.SectionUserPermission\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.SectionUserPermission",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Switch\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Switch",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.TreeAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.TreeAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowChangePassword\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowChangePassword",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowDeleteAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowDeleteAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowDisableAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowDisableAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowEnableAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowEnableAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowExternalLoginAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowExternalLoginAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowMfaAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowMfaAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowUnlockAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowUnlockAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.UserPermission.Fallback\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.UserPermission.Fallback",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.UserPermission.Language\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.UserPermission.Language",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceContentTypeAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceContentTypeAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceContentTypeUnique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceContentTypeUnique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceEntityType\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceEntityType",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<string>": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbContentWorkspaceIsLoadedConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Workspace.ContentIsLoaded",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbCurrentUserGroupIdConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CurrentUser.GroupId",
+                    "type": "string"
+                },
+                "allOf": {
+                    "description": "The user groups that the current user must be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "match": {
+                    "description": "The user group that the current user must be a member of to pass the condition.",
+                    "examples": "['guid1']",
+                    "type": "string"
+                },
+                "noneOf": {
+                    "description": "The user group(s) that the current user must not be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "oneOf": {
+                    "description": "The user group(s) that the current user must be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbEntityContentTypeUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.EntityContentType.Unique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the unique (GUID) of the entity content type for which this extension should be available.",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more unique (GUIDs) of entity content types for which this extension should be available.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbEntityTypeConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Entity.Type%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbEntityUnique": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "UmbEntityUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Entity.Unique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "oneOf": {
+                            "items": {
+                                "$ref": "#/definitions/UmbEntityUnique"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbFallbackUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.UserPermission.Fallback%22%3E"
+                },
+                {
+                    "properties": {
+                        "allOf": {
+                            "description": "The user must have all of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "oneOf": {
+                            "description": "The user must have at least one of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbInModalConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.InModal",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "The expected modal state to match.\n- `true`: Condition is permitted when inside a modal (default)\n- `false`: Condition is permitted when NOT inside a modal",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsAdminConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CurrentUser.IsAdmin",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsRoutableContextConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.IsRoutableContext",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "The expected routable context state to match.\n- `true`: Condition is permitted when inside a routable context (default)\n- `false`: Condition is permitted when NOT inside a routable context",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsServerProductionModeConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Server.IsProductionMode",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "If true (default), the condition is permitted when in Production mode.\nIf false, the condition is permitted when NOT in Production mode.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbItemDataResolverConstructor<UmbItemModel>": {
+            "type": "object"
+        },
+        "UmbLanguageUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.UserPermission.Language%22%3E"
+                },
+                {
+                    "properties": {
+                        "allOf": {
+                            "description": "The user must have all of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "match": {
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "The user must have at least one of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbLocalizationDictionary": {
+            "type": "object"
+        },
+        "UmbPropertyHasValueConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Property.HasValue",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbSectionUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.SectionUserPermission%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceContentTypeAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceContentTypeAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define a content type alias in which workspace this extension should be available",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more content type aliases in which workspace this extension should be available",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceContentTypeUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceContentTypeUnique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define a content type unique (GUID) in which workspace this extension should be available",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more content type unique (GUIDs) in which workspace this extension should be available",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceEntityIsNewConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceEntityIsNew",
+                    "type": "string"
+                },
+                "match": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias",
+                "match"
+            ],
+            "type": "object"
+        },
+        "UmbWorkspaceEntityTypeConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceEntityType%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the workspace that this extension should be available in",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
         },
         "UmbracoPackageImportmap": {
             "properties": {
@@ -46,10 +16881,38 @@
                 "type": "string"
             },
             "type": "object"
+        },
+        "WorkspaceAliasConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceAlias",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "Define the workspace that this extension should be available in",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Define one or more workspaces that this extension should be available in",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
         }
     },
     "description": "Umbraco package manifest JSON",
     "properties": {
+        "allowCacheBusting": {
+            "default": true,
+            "title": "Whether Umbraco automatically appends a cache-buster to this package's clean /App_Plugins assets (importmap and extensions)",
+            "type": "boolean"
+        },
         "allowPackageTelemetry": {
             "default": true,
             "title": "Decides if the package sends telemetry data for collection",
@@ -66,8 +16929,351 @@
             "type": "boolean"
         },
         "extensions": {
-            "$ref": "#/definitions/(ManifestUfmFilter%7CManifestUfmComponent%7CManifestMarkedExtension%7CManifestPropertyValueCloner%7CUmbPropertyEditorExtensions%7CManifestPropertyValuePreset%7CManifestPropertyValueResolver%7CManifestEntityActionDuplicateToKind%7CManifestEntityActionMoveToKind%7CManifestEntityActionReloadTreeItemChildrenKind%7CManifestEntityActionSortChildrenOfKind%7CUmbSectionExtensions%7CManifestDashboard%7CManifestWorkspaceDefaultKind%7CManifestWorkspaceActionDefaultKind%7CManifestWorkspaceFooterApp%7CManifestWorkspaceFooterAppMenuBreadcrumbKind%7CManifestWorkspaceFooterAppVariantMenuBreadcrumbKind%7CManifestWorkspaceViewContentTypeDesignEditorKind%7CManifestWorkspaceView%3CMetaWorkspaceView%3E%7CManifestWorkspaceRoutableKind%7CManifestWorkspaceContext%7CManifestTreeItem%7CManifestTree%7CManifestEntityActionCreateFolderKind%7CManifestEntityActionDeleteFolderKind%7CManifestEntityActionUpdateFolderKind%7CManifestEntityCreateOptionActionFolderKind%7CManifestMenu%7CManifestMenuItem%7CManifestMenuItemActionKind%7CManifestMenuItemLinkKind%7CManifestWorkspaceContextMenuStructureKind%7CManifestMenuItemTreeKind%7CManifestModal%7CManifestCollectionAction%7CManifestCollection%7CManifestCollectionActionCreateKind%7CManifestCollectionTextFilter%7CManifestCollectionMenu%7CManifestCollectionView%7CManifestCollectionViewTableKind%7CManifestWorkspaceViewCollectionKind%7CManifestValueSummary%7CManifestAuditLogActionDefaultKind%7CManifestEntityActionContentRollbackKind%7CManifestWorkspaceInfoAppAuditLogKind%7CManifestWorkspaceViewContentCollectionKind%7CManifestEntityActionSortChildrenOfContentKind%7CManifestUserProfileApp%7CManifestAuthProvider%7CManifestIcons%7CManifestEntityUserPermission%7CManifestGranularUserPermission%7CManifestLocalization%7CManifestPickerSearchResultItem%7CManifestCollectionMenuItem%7CManifestPropertyEditorDataSource%7CManifestEntityActionDeleteKind%7CManifestEntityActionDefaultKind%7CManifestEntityActionCreateKind%7CManifestSearchProvider%7CManifestSearchResultItem%7CManifestGlobalSearch%7CManifestAppEntryPoint%7CManifestBackofficeEntryPoint%7CManifestEntryPoint%7CUmbCoreManifestTypes%7CManifestEntityItemRef%3CMetaEntityItemRef%3E%7CManifestDataSourceDataMapping%3CMetaDataSourceDataMapping%3E%7CManifestPropertyContext%3CMetaPropertyContext%3E%7CManifestSectionContext%3CMetaSectionContext%3E%7CManifestWorkspaceActionMenuItem%3CMetaWorkspaceActionMenuItem%3E%7CManifestWorkspaceActionMenuItemDefaultKind%3CMetaWorkspaceActionMenuItemDefaultKind%3E%7CManifestWorkspaceInfoApp%3CMetaWorkspaceInfoApp%3E%7CManifestWorkspaceAction%3CMetaWorkspaceAction%2CUmbWorkspaceAction%3CMetaWorkspaceAction%3E%3E%7CManifestWorkspace%3CMetaWorkspace%2CUmbControllerHostElement%2CUmbWorkspaceContext%3E%7CManifestEntityCreateOptionAction%3CMetaEntityCreateOptionAction%3E%7CManifestEntityCollectionItemCard%3CMetaEntityCollectionItemCard%3E%7CManifestEntityCollectionItemRef%3CMetaEntityCollectionItemRef%3E%7CManifestAuditLogAction%3CMetaAuditLogAction%3E%7CManifestCurrentUserAction%3CMetaCurrentUserAction%3E%7CManifestPropertyValidationPathTranslator%3Cany%3E%7CManifestEntityAction%3CMetaEntityAction%3E%7CManifestEntityBulkActionDeleteKind%7CUmbEntityBulkActionExtensions%7CManifestExternalLoginProvider%7CManifestGlobalContext%7CManifestHeaderApp%7CManifestHeaderAppButtonKind%7CManifestMfaLoginProvider%7CManifestPreviewAppProvider%7CManifestRepository%3CUmbApi%3E%7CUmbStoreExtensions)%5B%5D",
-            "title": "An array of Umbraco package manifest types that will be installed"
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/ManifestBase"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUfmFilter"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUfmComponent"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMarkedExtension"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValueCloner"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorUi"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorSchema"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValuePreset"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValueResolver"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeAction"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDuplicateToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionMoveToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionReloadTreeItemChildrenKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionSortChildrenOfKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterAppMenuBreadcrumbKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewContentTypeDesignEditorKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceView%3CMetaWorkspaceView%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceRoutableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceContext"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionRoute"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionSidebarApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSection"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestDashboard"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTree"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionCreateFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDeleteFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionUpdateFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCreateOptionActionFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenu"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemActionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemLinkKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceContextMenuStructureKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemTreeKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeItemCard"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewTreeKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeViewTableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestModal"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionAction"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollection"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionTextFilter"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionMenu"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionViewTableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewCollectionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestValueSummary"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuditLogActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentRollbackKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceInfoAppAuditLogKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewContentCollectionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionSortChildrenOfContentKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentPublishKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUserProfileApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuthProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestIcons"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityUserPermission"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGranularUserPermission"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestLocalization"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentUnpublishKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPickerSearchResultItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionMenuItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorDataSource"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDeleteKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSearchProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSearchResultItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGlobalSearch"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCondition"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAppEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestBackofficeEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestBundle%3CUmbCoreManifestTypes%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityItemRef%3CMetaEntityItemRef%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestDataSourceDataMapping%3CMetaDataSourceDataMapping%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyContext%3CMetaPropertyContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCreateOptionAction%3CMetaEntityCreateOptionAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionMenuItem%3CMetaWorkspaceActionMenuItem%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionMenuItemDefaultKind%3CMetaWorkspaceActionMenuItemDefaultKind%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceInfoApp%3CMetaWorkspaceInfoApp%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceAction%3CMetaWorkspaceAction%2CUmbWorkspaceAction%3CMetaWorkspaceAction%3E%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspace%3CMetaWorkspace%2CUmbControllerHostElement%2CUmbWorkspaceContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionContext%3CMetaSectionContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCollectionItemCard%3CMetaEntityCollectionItemCard%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCollectionItemRef%3CMetaEntityCollectionItemRef%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuditLogAction%3CMetaAuditLogAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCurrentUserAction%3CMetaCurrentUserAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValidationPathTranslator%3Cany%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityAction%3CMetaEntityAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDeleteKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkAction%3CMetaEntityBulkAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDefaultKind%3CMetaEntityBulkActionDefaultKind%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDuplicateToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionMoveToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionTrashKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestExternalLoginProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGlobalContext"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestHeaderApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestHeaderAppButtonKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMfaLoginProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPreviewAppProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestRepository%3CUmbApi%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestStore"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestItemStore"
+                    }
+                ]
+            },
+            "title": "An array of Umbraco package manifest types that will be installed",
+            "type": "array"
         },
         "id": {
             "title": "The unique identifier of the Umbraco package",

--- a/SgfDevs/SgfDevs.csproj
+++ b/SgfDevs/SgfDevs.csproj
@@ -6,13 +6,13 @@
     <PackageReference Include="AutoMapper" Version="16.2.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
-    <PackageReference Include="ReverseMarkdown" Version="6.1.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="ReverseMarkdown" Version="6.1.1" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.8.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" NoWarn="NU1510" />
-    <PackageReference Include="Umbraco.Cms" Version="18.0.2" />
-    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.0.2" />
+    <PackageReference Include="Umbraco.Cms" Version="18.1.0" />
+    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.1.0" />
     <PackageReference Include="Umbraco.StorageProviders.AzureBlob" Version="18.0.0" />
     <PackageReference Include="uSync" Version="18.0.3" />
     <PackageReference Include="Skybrud.Umbraco.Redirects" Version="18.0.0-alpha001" />

--- a/SgfDevs/SgfDevs.csproj
+++ b/SgfDevs/SgfDevs.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="ReverseMarkdown" Version="6.1.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.7.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" NoWarn="NU1510" />
     <PackageReference Include="Umbraco.Cms" Version="18.0.2" />
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.0.2" />

--- a/SgfDevs/appsettings-schema.Umbraco.Cms.json
+++ b/SgfDevs/appsettings-schema.Umbraco.Cms.json
@@ -111,6 +111,9 @@
         "DistributedJobSettings": {
           "$ref": "#/definitions/DistributedJobSettings"
         },
+        "ScheduledPublishing": {
+          "$ref": "#/definitions/ScheduledPublishingSettings"
+        },
         "Website": {
           "$ref": "#/definitions/WebsiteSettings"
         },
@@ -142,6 +145,11 @@
         "ResolveUrlsFromTextString": {
           "type": "boolean",
           "description": "Gets or sets a value indicating whether URLs should be resolved from text strings.\n            ",
+          "default": false
+        },
+        "SortChildrenByFieldFiresNotifications": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether sorting the children of a node by a field fires\nper-item save/sort notifications (and therefore webhooks).\n            ",
           "default": false
         },
         "Error404Collection": {
@@ -848,6 +856,12 @@
           "description": "Gets or sets a value for the time span to wait before considering a server stale, after it has last been accessed.\n            ",
           "format": "duration",
           "default": "00:02:00"
+        },
+        "TouchTimeout": {
+          "type": "string",
+          "description": "Gets or sets the maximum time to wait for a single server touch operation to complete before it is\nconsidered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring\njob keeps running rather than stopping permanently. This bounds how long the job waits on a single touch,\nnot how long a stalled connection itself takes to recover (which is governed by the database timeouts).\n            ",
+          "format": "duration",
+          "default": "00:01:00"
         }
       }
     },
@@ -876,6 +890,12 @@
         "TimeBetweenPruneOperations": {
           "type": "string",
           "description": "Gets or sets a value for the time to wait between each prune operations.\n            ",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "SyncTimeout": {
+          "type": "string",
+          "description": "Gets or sets the maximum time to wait for a single synchronization operation to complete before it is\nconsidered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring\njob keeps running rather than stopping permanently. This bounds how long the job waits on a single sync,\nnot how long a stalled connection itself takes to recover (which is governed by the database timeouts).\n            ",
           "format": "duration",
           "default": "00:01:00"
         }
@@ -1146,6 +1166,13 @@
             "string"
           ],
           "description": "Gets or sets a value specifying the name of the site.\n            "
+        },
+        "MachineIdentifier": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Gets or sets a stable identifier for this server instance used to track cache synchronization state.\n            "
         }
       }
     },
@@ -1281,7 +1308,8 @@
         "BatchSize": {
           "type": "integer",
           "description": "Gets or sets a value for how many items to index at a time.",
-          "format": "int32"
+          "format": "int32",
+          "default": 10000
         }
       }
     },
@@ -1309,8 +1337,31 @@
           "type": "string",
           "description": "Gets or sets the file name format arguments to use for log files.",
           "default": "MachineName"
+        },
+        "SessionIdLogging": {
+          "description": "Gets or sets a value determining how log events are enriched with a session identifier.",
+          "default": "SessionId",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SessionIdLoggingMode"
+            }
+          ]
         }
       }
+    },
+    "SessionIdLoggingMode": {
+      "type": "string",
+      "description": "Determines how request logging enriches log events with a session identifier.",
+      "x-enumNames": [
+        "None",
+        "SessionId",
+        "CookieHash"
+      ],
+      "enum": [
+        "None",
+        "SessionId",
+        "CookieHash"
+      ]
     },
     "NuCacheSettings": {
       "type": "object",
@@ -1335,6 +1386,12 @@
           "type": "boolean",
           "description": "Gets or sets a value indicating whether to use paged SQL queries for nucache.\n            ",
           "default": true
+        },
+        "ContentTypeRebuildDeleteBatchSize": {
+          "type": "integer",
+          "description": "Gets or sets the number of content items whose stale NuCache rows are deleted per batch during a\ncontent type structural rebuild.\n            ",
+          "format": "int32",
+          "default": 2000
         }
       }
     },
@@ -1818,6 +1875,11 @@
       "type": "object",
       "description": "Typed configuration options for the plugins.\n            ",
       "properties": {
+        "Cachebuster": {
+          "type": "string",
+          "description": "Gets or sets an optional host-controlled cache-buster for package /App_Plugins assets. When set (e.g.\nto a build number or deployment id), it is appended as umb__rnd to every package's assets — importmap\nand extensions — forcing a re-fetch regardless of each package's own version. Empty by default (no effect).\n            ",
+          "default": ""
+        },
         "BrowsableFileExtensions": {
           "type": "array",
           "description": "Gets or sets the allowed file extensions (including the period \".\") that should be accessible from the browser.\n            ",
@@ -2282,6 +2344,14 @@
           "description": "Gets or sets the duration that items remain in the seed cache.\n            ",
           "format": "duration",
           "default": "365.00:00:00"
+        },
+        "MaximumLocalCacheItems": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gets or sets the maximum number of converted items kept in the in-process (L0) published-content\ncache, or null for no limit.\n            ",
+          "format": "int32"
         }
       }
     },
@@ -2306,6 +2376,23 @@
           "description": "Gets or sets the maximum execution time for a distributed job before it is considered timed out.\nWhen a job exceeds this time, it is considered stale and can be picked up by another server for recovery and restarted.\n            ",
           "format": "duration",
           "default": "00:05:00"
+        }
+      }
+    },
+    "ScheduledPublishingSettings": {
+      "type": "object",
+      "description": "Settings for scheduled publishing.",
+      "properties": {
+        "Period": {
+          "type": "string",
+          "description": "Gets or sets a value for how often scheduled publishing runs.",
+          "format": "duration",
+          "default": "00:01:00"
+        },
+        "AlignToClock": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether scheduled publishing runs are aligned to clock boundaries\nderived from Period (for example, on the minute, or every N seconds), rather than drifting\nbased on when the previous run completed.",
+          "default": false
         }
       }
     },

--- a/SgfDevs/umbraco-package-schema.json
+++ b/SgfDevs/umbraco-package-schema.json
@@ -1,8 +1,16843 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "(ManifestUfmFilter|ManifestUfmComponent|ManifestMarkedExtension|ManifestPropertyValueCloner|UmbPropertyEditorExtensions|ManifestPropertyValuePreset|ManifestPropertyValueResolver|ManifestEntityActionDuplicateToKind|ManifestEntityActionMoveToKind|ManifestEntityActionReloadTreeItemChildrenKind|ManifestEntityActionSortChildrenOfKind|UmbSectionExtensions|ManifestDashboard|ManifestWorkspaceDefaultKind|ManifestWorkspaceActionDefaultKind|ManifestWorkspaceFooterApp|ManifestWorkspaceFooterAppMenuBreadcrumbKind|ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind|ManifestWorkspaceViewContentTypeDesignEditorKind|ManifestWorkspaceView<MetaWorkspaceView>|ManifestWorkspaceRoutableKind|ManifestWorkspaceContext|ManifestTreeItem|ManifestTree|ManifestEntityActionCreateFolderKind|ManifestEntityActionDeleteFolderKind|ManifestEntityActionUpdateFolderKind|ManifestEntityCreateOptionActionFolderKind|ManifestMenu|ManifestMenuItem|ManifestMenuItemActionKind|ManifestMenuItemLinkKind|ManifestWorkspaceContextMenuStructureKind|ManifestMenuItemTreeKind|ManifestModal|ManifestCollectionAction|ManifestCollection|ManifestCollectionActionCreateKind|ManifestCollectionTextFilter|ManifestCollectionMenu|ManifestCollectionView|ManifestCollectionViewTableKind|ManifestWorkspaceViewCollectionKind|ManifestValueSummary|ManifestAuditLogActionDefaultKind|ManifestEntityActionContentRollbackKind|ManifestWorkspaceInfoAppAuditLogKind|ManifestWorkspaceViewContentCollectionKind|ManifestEntityActionSortChildrenOfContentKind|ManifestUserProfileApp|ManifestAuthProvider|ManifestIcons|ManifestEntityUserPermission|ManifestGranularUserPermission|ManifestLocalization|ManifestPickerSearchResultItem|ManifestCollectionMenuItem|ManifestPropertyEditorDataSource|ManifestEntityActionDeleteKind|ManifestEntityActionDefaultKind|ManifestEntityActionCreateKind|ManifestSearchProvider|ManifestSearchResultItem|ManifestGlobalSearch|ManifestAppEntryPoint|ManifestBackofficeEntryPoint|ManifestEntryPoint|UmbCoreManifestTypes|ManifestEntityItemRef<MetaEntityItemRef>|ManifestDataSourceDataMapping<MetaDataSourceDataMapping>|ManifestPropertyContext<MetaPropertyContext>|ManifestSectionContext<MetaSectionContext>|ManifestWorkspaceActionMenuItem<MetaWorkspaceActionMenuItem>|ManifestWorkspaceActionMenuItemDefaultKind<MetaWorkspaceActionMenuItemDefaultKind>|ManifestWorkspaceInfoApp<MetaWorkspaceInfoApp>|ManifestWorkspaceAction<MetaWorkspaceAction,UmbWorkspaceAction<MetaWorkspaceAction>>|ManifestWorkspace<MetaWorkspace,UmbControllerHostElement,UmbWorkspaceContext>|ManifestEntityCreateOptionAction<MetaEntityCreateOptionAction>|ManifestEntityCollectionItemCard<MetaEntityCollectionItemCard>|ManifestEntityCollectionItemRef<MetaEntityCollectionItemRef>|ManifestAuditLogAction<MetaAuditLogAction>|ManifestCurrentUserAction<MetaCurrentUserAction>|ManifestPropertyValidationPathTranslator<any>|ManifestEntityAction<MetaEntityAction>|ManifestEntityBulkActionDeleteKind|UmbEntityBulkActionExtensions|ManifestExternalLoginProvider|ManifestGlobalContext|ManifestHeaderApp|ManifestHeaderAppButtonKind|ManifestMfaLoginProvider|ManifestPreviewAppProvider|ManifestRepository<UmbApi>|UmbStoreExtensions)[]": {
+        "CollectionAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.CollectionAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "The collection that this extension should be available in",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "DelayConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Delay%22%3E"
+                },
+                {
+                    "properties": {
+                        "offset": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "offset"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "ManifestAppEntryPoint": {
+            "description": "Manifest for an `appEntryPoint`, which is loaded up front when the app starts.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.\nThis is useful for extensions that need to be loaded up front, like an `authProvider`.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "appEntryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
             "type": "object"
+        },
+        "ManifestAuditLogAction<MetaAuditLogAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuditLogAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "auditLogAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestAuditLogActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuditLogActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "auditLogAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestAuthProvider": {
+            "description": "Represents an authentication provider that can be used to authenticate users.\nThe provider needs to be registered in the API that the authorization request is sent to in order to be used.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forProviderName": {
+                    "description": "The provider name that this provider is for.",
+                    "examples": "'Umbraco.Github'",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaAuthProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "authProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forProviderName",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBackofficeEntryPoint": {
+            "description": "Manifest for an `backofficeEntryPoint`, which is loaded after the Backoffice has been loaded and authentication has been done.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "backofficeEntryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBase": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestBundle<UmbCoreManifestTypes>": {
+            "description": "This type of extension takes a JS module and registers all exported manifests from the pointed JS file.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "bundle",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollection": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollection"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collection",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionAction": {
+            "description": "An action to perform on an entity\nFor example for content you may wish to create a new document etc",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionMenu": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionMenu"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "collectionMenu",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionMenuItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "collectionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionTextFilter": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionTextFilter",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCollectionViewTableKind": {
+            "description": "Manifest type for the `table` kind of `collectionView`.\nAllows registering a table collection view with custom columns via manifest meta.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "table",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCollectionViewTableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "collectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCondition": {
+            "description": "This type of extension takes a JS module and registers all exported manifests from the pointed JS file.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "condition",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestCurrentUserAction<MetaCurrentUserAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaCurrentUserAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "currentUserAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestDashboard": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaDashboard",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "dashboard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestDataSourceDataMapping<MetaDataSourceDataMapping>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forDataModel": {
+                    "type": "string"
+                },
+                "forDataSource": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaDataSourceDataMapping"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "dataSourceDataMapping",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forDataModel",
+                "forDataSource",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityAction<MetaEntityAction>": {
+            "description": "An action to perform on an entity\nFor example for content you may wish to create a new document etc",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentPublishKind": {
+            "description": "Manifest for an entity action registered against the shared `contentPublish` kind.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentPublish",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentPublishKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentRollbackKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentRollback",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentRollbackKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionContentUnpublishKind": {
+            "description": "Manifest for an entity action registered against the shared `contentUnpublish` kind.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentUnpublish",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionContentUnpublishKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionCreateFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderCreate",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionCreateKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDeleteFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderDelete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDeleteKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "delete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDeleteKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "duplicateTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionDuplicateToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionMoveToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "moveTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionMoveToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionReloadTreeItemChildrenKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "reloadTreeItemChildren",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionReloadTreeItemChildrenKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionSortChildrenOfContentKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "sortChildrenOfContent",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionSortChildrenOfContentKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionSortChildrenOfKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "sortChildrenOf",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionSortChildrenOfKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityActionUpdateFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folderUpdate",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkAction<MetaEntityBulkAction>": {
+            "description": "An action to perform on multiple entities\nFor example for content you may wish to move one or more documents in bulk",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDefaultKind<MetaEntityBulkActionDefaultKind>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDeleteKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "delete",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDeleteKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "duplicateTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionDuplicateToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionMoveToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "moveTo",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionMoveToKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityBulkActionTrashKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "trash",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkActionTrashKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCollectionItemCard<MetaEntityCollectionItemCard>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "description": "The entity types this collection item supports.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCollectionItemCard",
+                    "description": "Additional metadata for the collection item."
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCollectionItemCard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCollectionItemRef<MetaEntityCollectionItemRef>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "description": "The entity types this collection item supports.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCollectionItemRef",
+                    "description": "Additional metadata for the collection item."
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCollectionItemRef",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCreateOptionAction<MetaEntityCreateOptionAction>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCreateOptionAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCreateOptionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityCreateOptionActionFolderKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "folder",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityCreateOptionActionFolderKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityCreateOptionAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityItemRef<MetaEntityItemRef>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityItemRef",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "entityItemRef",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntityUserPermission": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityUserPermission"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entityUserPermission",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestEntryPoint": {
+            "description": "Manifest for an `entryPoint`, which is loaded after the Backoffice has been loaded and authentication has been done.\n\nThis type of extension gives full control and will simply load the specified JS file.\nYou could have custom logic to decide which extensions to load/register by using extensionRegistry.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entryPoint",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestExternalLoginProvider": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaExternalLoginProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "externalLoginProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGlobalContext": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "globalContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGlobalSearch": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaGlobalSearch"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "globalSearch",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestGranularUserPermission": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaGranularUserPermission",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "userGranularPermission",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestHeaderApp": {
+            "description": "Header apps are displayed in the top right corner of the backoffice\nThe two provided header apps are the search and the user menu",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "headerApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestHeaderAppButtonKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "button",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaHeaderAppButtonKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "headerApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestIcons": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "icons",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestItemStore": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "itemStore",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestLocalization": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaLocalization"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "localization",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMarkedExtension": {
+            "description": "The `markedExtension` extension-type is currently for internal use and should be considered experimental.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMarkedExtension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "markedExtension",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenu": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "menu",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItem",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemActionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "action",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemActionKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemLinkKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "link",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemLinkKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMenuItemTreeKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "tree",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMenuItemTreeKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "menuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestMfaLoginProvider": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forProviderName": {
+                    "description": "The provider names that this provider is for.",
+                    "examples": "'Umbraco.GoogleAuthenticator'",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaMfaLoginProvider",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "mfaLoginProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forProviderName",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestModal": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "modal",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPickerSearchResultItem": {
+            "description": "Represents a picker search result element.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "pickerSearchResultItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPreviewAppProvider": {
+            "description": "Preview apps are displayed in the menu of the preview window.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "previewApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyContext<MetaPropertyContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "forPropertyEditorUis": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyContext"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "propertyContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forPropertyEditorUis",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorDataSource": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "dataSourceType": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorDataSource"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorDataSource",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "dataSourceType",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorSchema": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorSchema"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorSchema",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyEditorUi": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyEditorUi",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyEditorUi",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValidationPathTranslator<any>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValidationPathTranslator",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValueCloner": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValueCloner",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValuePreset": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forPropertyEditorSchemaAlias": {
+                    "type": "string"
+                },
+                "forPropertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValuePreset",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestPropertyValueResolver": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "forEditorAlias": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaPropertyValueResolver"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "propertyValueResolver",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEditorAlias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestRepository<UmbApi>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "repository",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSearchProvider": {
+            "description": "Represents an search provider that can be used to search.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSearchProvider"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "searchProvider",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSearchResultItem": {
+            "description": "Represents a search result element.",
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "searchResultItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSection": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSection"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "section",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionContext<MetaSectionContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionContext"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionRoute": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionRoute"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "sectionRoute",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionSidebarApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionSidebarApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestSectionView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaSectionView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "sectionView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestStore": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "store",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTree": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTree"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "tree",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeAction": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeActionCreateKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "create",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeItem": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "treeItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeItemCard": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "treeItemCard",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forEntityTypes",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeView": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forTrees": {
+                    "description": "The tree aliases this view applies to. When omitted, the view applies to all trees.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestTreeViewTableKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forTrees": {
+                    "description": "The tree aliases this view applies to. When omitted, the view applies to all trees.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "table",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaTreeViewTableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "treeView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUfmComponent": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUfmComponent"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ufmComponent",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUfmFilter": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUfmFilter"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ufmFilter",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestUserProfileApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaUserProfileApp",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "userProfileApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestValueSummary": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forValueType": {
+                    "description": "The value type this summary is registered for.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaValueSummary"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "valueSummary",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "valueResolver": {
+                    "description": "Optional resolver for batch-resolving raw values before rendering.\nUsed by the coordinator for efficient batching across multiple elements.",
+                    "type": "object"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forValueType",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspace<MetaWorkspace,UmbControllerHostElement,UmbWorkspaceContext>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspace"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceAction<MetaWorkspaceAction,UmbWorkspaceAction<MetaWorkspaceAction>>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionMenuItem<MetaWorkspaceActionMenuItem>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forWorkspaceActions": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define which workspace actions this menu item should be shown for.",
+                    "examples": "[\r\n['Umb.WorkspaceAction.Document.Save', 'Umb.WorkspaceAction.Document.SaveAndPublish'],\r\n\"Umb.WorkspaceAction.Document.Save\"\r\n]"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionMenuItem"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceActionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forWorkspaceActions",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceActionMenuItemDefaultKind<MetaWorkspaceActionMenuItemDefaultKind>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "forWorkspaceActions": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define which workspace actions this menu item should be shown for.",
+                    "examples": "[\r\n['Umb.WorkspaceAction.Document.Save', 'Umb.WorkspaceAction.Document.SaveAndPublish'],\r\n\"Umb.WorkspaceAction.Document.Save\"\r\n]"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceActionMenuItemDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceActionMenuItem",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "forWorkspaceActions",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceContext": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceContextMenuStructureKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "menuStructure",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceContextMenuStructureKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceContext",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceDefaultKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "default",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceDefaultKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterApp": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterAppMenuBreadcrumbKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "menuBreadcrumb",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "variantMenuBreadcrumb",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceFooterApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceInfoApp<MetaWorkspaceInfoApp>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceInfoApp",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceInfoApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceInfoAppAuditLogKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "auditLog",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceInfoAppAuditLogKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceInfoApp",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceRoutableKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "routable",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceRoutableKind"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "workspace",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceView<MetaWorkspaceView>": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewCollectionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "collection",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewCollectionKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewContentCollectionKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentCollection",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceView",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewContentTypeDesignEditorKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "contentTypeDesignEditor",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewContentTypeDesignEditorKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ManifestWorkspaceViewTreeKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "tree",
+                    "description": "The kind of the extension, used to group extensions together",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaWorkspaceViewTreeKind",
+                    "description": "This contains properties specific to the type of extension"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "type": {
+                    "const": "workspaceView",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "kind",
+                "meta",
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "MetaAuditLogAction": {
+            "type": "object"
+        },
+        "MetaAuditLogActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaAuthProvider": {
+            "properties": {
+                "behavior": {
+                    "description": "The behavior of the provider when it is used.",
+                    "properties": {
+                        "autoRedirect": {
+                            "default": false,
+                            "description": "If true, the user will be redirected to the provider's login page immediately.",
+                            "type": "boolean"
+                        },
+                        "popupFeatures": {
+                            "default": "'width=600,height=600,menubar=no,location=no,resizable=yes,scrollbars=yes,status=no,toolbar=no'",
+                            "description": "The features of the popup that is opened when the user logs in.",
+                            "type": "string"
+                        },
+                        "popupTarget": {
+                            "default": "'umbracoAuthPopup'",
+                            "description": "The target of the popup that is opened when the user logs in.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "defaultView": {
+                    "description": "The default view of the provider that is shown to the user.\nIf no element is provided, then the button will be rendered as a",
+                    "properties": {
+                        "color": {
+                            "default": "'secondary'",
+                            "description": "The color of the provider that is shown to the user.",
+                            "enum": [
+                                "",
+                                "danger",
+                                "default",
+                                "invalid",
+                                "positive",
+                                "warning"
+                            ],
+                            "type": "string"
+                        },
+                        "icon": {
+                            "default": "'icon-cloud'",
+                            "description": "The icon of the provider that is shown to the user.",
+                            "examples": "['icon-cloud', 'icon-github', 'icon-google', 'icon-facebook', 'icon-twitter', 'icon-x', 'icon-microsoft']",
+                            "type": "string"
+                        },
+                        "look": {
+                            "default": "'default'",
+                            "description": "The look of the provider that is shown to the user.",
+                            "enum": [
+                                "",
+                                "default",
+                                "outline",
+                                "placeholder",
+                                "primary",
+                                "secondary"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "label": {
+                    "description": "The label of the provider that is shown to the user.",
+                    "type": "string"
+                },
+                "linking": {
+                    "description": "The linking options of the provider when it is used.",
+                    "properties": {
+                        "allowManualLinking": {
+                            "default": false,
+                            "description": "If true, the user will be able to link the provider to an existing account.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MetaCollection": {
+            "properties": {
+                "noItemsLabel": {
+                    "type": "string"
+                },
+                "repositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "repositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionAction": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionMenu": {
+            "properties": {
+                "collectionRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionView": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the collection view",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the collection view",
+                    "type": "string"
+                },
+                "pathName": {
+                    "description": "The URL pathname for this collection view that can be deep linked to by sharing the url",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathName"
+            ],
+            "type": "object"
+        },
+        "MetaCollectionViewTableKind": {
+            "description": "Meta configuration for the `table` kind of `collectionView`.",
+            "properties": {
+                "columns": {
+                    "description": "Additional columns to render between the name and entity actions columns.",
+                    "items": {
+                        "$ref": "#/definitions/MetaCollectionViewTableKindColumn"
+                    },
+                    "type": "array"
+                },
+                "icon": {
+                    "description": "An icon to represent the collection view",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the collection view",
+                    "type": "string"
+                },
+                "pathName": {
+                    "description": "The URL pathname for this collection view that can be deep linked to by sharing the url",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaCollectionViewTableKindColumn": {
+            "description": "Configuration for a single column in a table collection view kind.",
+            "properties": {
+                "field": {
+                    "description": "The property name on the collection item model to display in this column.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The column header label. Supports localization strings (e.g. `#general_status`).",
+                    "type": "string"
+                },
+                "valueType": {
+                    "description": "Optional value type for rendering a value summary in this column.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "field",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaCurrentUserAction": {
+            "type": "object"
+        },
+        "MetaDashboard": {
+            "properties": {
+                "label": {
+                    "description": "The displayed name (label) in the navigation.",
+                    "type": "string"
+                },
+                "pathname": {
+                    "description": "This is the URL path part for this view. This is used for navigating or deep linking directly to the dashboard\nhttps://yoursite.com/section/settings/dashboard/my-dashboard-path",
+                    "examples": [
+                        "my-dashboard-path"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaDataSourceDataMapping": {
+            "type": "object"
+        },
+        "MetaEntityAction": {
+            "type": "object"
+        },
+        "MetaEntityActionContentPublishKind": {
+            "description": "Meta configuration for the `contentPublish` entity action kind.",
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "detailRepositoryAlias": {
+                    "description": "Alias of the detail repository used to load the content item.",
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "publishedNotificationMessage": {
+                    "description": "Overrides the success notification message when invariant content is published.\nUse a localization key, e.g. `#speechBubbles_editContentPublishedText`.",
+                    "type": "string"
+                },
+                "publishingRepositoryAlias": {
+                    "description": "Alias of the publishing repository used to perform the publish operation.",
+                    "type": "string"
+                },
+                "variantPublishedNotificationMessage": {
+                    "description": "Overrides the success notification message when one or more variants are published.\nUse a localization key, e.g. `#speechBubbles_editVariantPublishedText` — the list of published variants\nis passed as the first term argument, so a plain (non-key) string will not include it.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "label",
+                "publishingRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionContentRollbackKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "rollbackNotificationMessage": {
+                    "type": "string"
+                },
+                "rollbackRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "label",
+                "rollbackRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionContentUnpublishKind": {
+            "description": "Meta configuration for the `contentUnpublish` entity action kind.",
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "configurationRepositoryAlias": {
+                    "description": "Alias of the configuration repository used by the modal to read unpublish behaviour configuration.",
+                    "type": "string"
+                },
+                "detailRepositoryAlias": {
+                    "description": "Alias of the detail repository used to load the content item.",
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "description": "Alias of the item repository used by the modal to present the affected items.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "publishingRepositoryAlias": {
+                    "description": "Alias of the publishing repository used to perform the unpublish operation.",
+                    "type": "string"
+                },
+                "referenceRepositoryAlias": {
+                    "description": "Alias of the reference repository used by the modal to warn about inbound references.",
+                    "type": "string"
+                },
+                "unpublishedNotificationMessage": {
+                    "description": "Overrides the success notification message when content is unpublished.\nUse a localization key, e.g. `#speechBubbles_contentUnpublished`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "configurationRepositoryAlias",
+                "detailRepositoryAlias",
+                "icon",
+                "itemRepositoryAlias",
+                "label",
+                "publishingRepositoryAlias",
+                "referenceRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionCreateKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDeleteKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "confirm": {
+                    "properties": {
+                        "headline": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "icon",
+                "itemRepositoryAlias",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionDuplicateToKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "duplicateRepositoryAlias": {
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "duplicateRepositoryAlias",
+                "icon",
+                "label",
+                "treeAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionFolderKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "folderRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "folderRepositoryAlias",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionMoveToKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "moveRepositoryAlias": {
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "moveRepositoryAlias",
+                "treeAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionReloadTreeItemChildrenKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionSortChildrenOfContentKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemDataResolver": {
+                    "$ref": "#/definitions/UmbItemDataResolverConstructor%3CUmbItemModel%3E"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "sortChildrenOfRepositoryAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "sortChildrenOfRepositoryAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityActionSortChildrenOfKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "sortChildrenOfRepositoryAlias": {
+                    "type": "string"
+                },
+                "treeRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "sortChildrenOfRepositoryAlias",
+                "treeRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkAction": {
+            "type": "object"
+        },
+        "MetaEntityBulkActionDefaultKind": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaEntityBulkActionDeleteKind": {
+            "properties": {
+                "detailRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "itemRepositoryAlias": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "detailRepositoryAlias",
+                "itemRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionDuplicateToKind": {
+            "properties": {
+                "alias": {
+                    "description": "The alias of the extension, ensure it is unique",
+                    "type": "string"
+                },
+                "api": {
+                    "description": "The file location of the api javascript file to load",
+                    "type": "string"
+                },
+                "bulkDuplicateRepositoryAlias": {
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Set the conditions for when the extension should be loaded",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/UmbEntityUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbLanguageUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsRoutableContextConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbPropertyHasValueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbEntityContentTypeUniqueConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/WorkspaceAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityIsNewConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbWorkspaceEntityTypeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbContentWorkspaceIsLoadedConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbSectionUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/TreeAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/CollectionAliasConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCollectionHasItemsConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbCurrentUserGroupIdConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsAdminConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbIsServerProductionModeConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowChangePassword%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDeleteAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowDisableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowEnableAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowExternalLoginAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowMfaAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.User.AllowUnlockAction%22%3E"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbFallbackUserPermissionConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbInModalConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/DelayConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/SwitchConditionConfig"
+                            },
+                            {
+                                "$ref": "#/definitions/UmbConditionConfigBase%3Cstring%3E"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "element": {
+                    "description": "The file location of the element javascript file to load",
+                    "type": "string"
+                },
+                "elementName": {
+                    "description": "The HTML web component name to use such as 'my-dashboard'\nNote it is NOT <my-dashboard></my-dashboard>, just the element name.",
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "forEntityTypes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "js": {
+                    "description": "The file location of the javascript file to load",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the extension, used to group extensions together",
+                    "examples": [
+                        "button"
+                    ]
+                },
+                "meta": {
+                    "$ref": "#/definitions/MetaEntityBulkAction"
+                },
+                "name": {
+                    "description": "The friendly name of the extension",
+                    "type": "string"
+                },
+                "overwrites": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "Define one or more extension aliases that this extension should overwrite."
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "entityBulkAction",
+                    "description": "The type of extension such as dashboard etc...",
+                    "type": "string"
+                },
+                "weight": {
+                    "description": "Extensions such as dashboards are ordered by weight with higher numbers being first in the list",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "bulkDuplicateRepositoryAlias",
+                "forEntityTypes",
+                "meta",
+                "name",
+                "treeAlias",
+                "type"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionMoveToKind": {
+            "properties": {
+                "bulkMoveRepositoryAlias": {
+                    "type": "string"
+                },
+                "foldersOnly": {
+                    "type": "boolean"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "description": "The alias of a search provider used to enable search in the destination picker.",
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bulkMoveRepositoryAlias",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityBulkActionTrashKind": {
+            "properties": {
+                "bulkTrashRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "bulkTrashRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaEntityCollectionItemCard": {
+            "type": "object"
+        },
+        "MetaEntityCollectionItemRef": {
+            "type": "object"
+        },
+        "MetaEntityCreateOptionAction": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "description": {
+                    "description": "A description of the action to be performed",
+                    "examples": [
+                        "Create a document type with a template",
+                        "Create a document from a blueprint"
+                    ],
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create with Template",
+                        "Create from Blueprint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityCreateOptionActionFolderKind": {
+            "properties": {
+                "additionalOptions": {
+                    "description": "The action requires additional input from the user.\nA dialog will prompt the user for more information or to make a choice.",
+                    "type": "{boolean}"
+                },
+                "description": {
+                    "description": "A description of the action to be performed",
+                    "examples": [
+                        "Create a document type with a template",
+                        "Create a document from a blueprint"
+                    ],
+                    "type": "string"
+                },
+                "folderRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create with Template",
+                        "Create from Blueprint"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "folderRepositoryAlias",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaEntityItemRef": {
+            "type": "object"
+        },
+        "MetaEntityUserPermission": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "verbs": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "verbs"
+            ],
+            "type": "object"
+        },
+        "MetaExternalLoginProvider": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaGlobalSearch": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "searchProviderAlias": {
+                    "type": "string"
+                },
+                "sectionAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "searchProviderAlias"
+            ],
+            "type": "object"
+        },
+        "MetaGranularUserPermission": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "descriptionKey": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "labelKey": {
+                    "type": "string"
+                },
+                "schemaType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "schemaType"
+            ],
+            "type": "object"
+        },
+        "MetaHeaderAppButtonKind": {
+            "properties": {
+                "href": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "href",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaLocalization": {
+            "properties": {
+                "culture": {
+                    "description": "The culture is a combination of a language and a country. The language is represented by an ISO 639-1 code and the country is represented by an ISO 3166-1 alpha-2 code.\r\nThe language and country are separated by a dash.\r\nThe value is used to describe the language of the translations according to the extension system\r\nand it will be set as the `lang` attribute on the `<html>` element.",
+                    "type": "string"
+                },
+                "direction": {
+                    "default": "ltr",
+                    "description": "The value is used to describe the direction of the translations according to the extension system\r\nand it will be set as the `dir` attribute on the `<html>` element. It defaults to `ltr`.",
+                    "enum": [
+                        "ltr",
+                        "rtl"
+                    ],
+                    "type": "string"
+                },
+                "localizations": {
+                    "$ref": "#/definitions/UmbLocalizationDictionary",
+                    "description": "The localizations."
+                }
+            },
+            "required": [
+                "culture"
+            ],
+            "type": "object"
+        },
+        "MetaMarkedExtension": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItem": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemActionKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemLinkKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "href",
+                "label",
+                "menus"
+            ],
+            "type": "object"
+        },
+        "MetaMenuItemTreeKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "hideTreeRoot": {
+                    "type": "boolean"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "menus": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "menus",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "MetaMfaLoginProvider": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaPropertyContext": {
+            "type": "object"
+        },
+        "MetaPropertyEditorDataSource": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyEditorSchema": {
+            "properties": {
+                "defaultPropertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                }
+            },
+            "required": [
+                "defaultPropertyEditorUiAlias"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyEditorUi": {
+            "properties": {
+                "group": {
+                    "default": "Common",
+                    "description": "The group that this property editor UI belongs to, which will be used to group\nthe property editor UIs in the property editor picker.\nIf not specified, the property editor UI will be grouped under \"Common\".\n\nCore property editors use localization keys prefixed with `#` (e.g. `\"#propertyEditorUIGroups_common\"`).\nExternal packages can use either display-ready names (e.g. `\"My Group\"`) or camelCase names\n(e.g. `\"myGroup\"`) which will be automatically converted to title case.",
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "description": "A list of keywords that can be used to search for this property editor UI in the property editor picker.\nIf not specified, the property editor UI will not have any keywords.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "propertyEditorSchemaAlias": {
+                    "description": "The alias of the property editor schema that this property editor UI is for.\nIf not specified, the property editor UI can only be used to configure other property editors.",
+                    "type": "string"
+                },
+                "settings": {
+                    "$ref": "#/definitions/PropertyEditorSettings"
+                },
+                "supportsDataSource": {
+                    "properties": {
+                        "enabled": {
+                            "description": "Whether the property editor UI is enabled for use with data sources.",
+                            "type": "{boolean}"
+                        },
+                        "forDataSourceTypes": {
+                            "description": "A list of allowed property editor data source kinds that can be used with this property editor UI.\nIf not specified, any data sources can be used.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "enabled",
+                        "forDataSourceTypes"
+                    ],
+                    "type": "object"
+                },
+                "supportsReadOnly": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "group",
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaPropertyValueResolver": {
+            "type": "object"
+        },
+        "MetaSearchProvider": {
+            "properties": {
+                "label": {
+                    "description": "The label of the provider that is shown to the user.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaSection": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                },
+                "preventUrlRetention": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaSectionContext": {
+            "type": "object"
+        },
+        "MetaSectionRoute": {
+            "properties": {
+                "path": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaSectionView": {
+            "properties": {
+                "icon": {
+                    "description": "The icon displayed for this view in the navigation.",
+                    "examples": [
+                        "box"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The displayed name (label) in the navigation.",
+                    "type": "string"
+                },
+                "pathname": {
+                    "description": "This is the URL path part for this view. This is used for navigating or deep linking directly to the view\nhttps://yoursite.com/section/settings/view/my-view-path",
+                    "examples": [
+                        "my-view-path"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon"
+            ],
+            "type": "object"
+        },
+        "MetaTree": {
+            "properties": {
+                "repositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "repositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaTreeAction": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaTreeView": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the tree view",
+                    "examples": [
+                        "icon-list",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the tree view",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaTreeViewTableKind": {
+            "properties": {
+                "columns": {
+                    "description": "Additional columns to render between the name and entity actions columns.",
+                    "items": {
+                        "$ref": "#/definitions/MetaTreeViewTableKindColumn"
+                    },
+                    "type": "array"
+                },
+                "icon": {
+                    "description": "An icon to represent the tree view",
+                    "examples": [
+                        "icon-list",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the tree view",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaTreeViewTableKindColumn": {
+            "properties": {
+                "field": {
+                    "description": "The property name on the tree item model to display in this column.",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The column header label. Supports localization strings (e.g. `#general_status`).",
+                    "type": "string"
+                },
+                "valueType": {
+                    "description": "Optional value type for rendering a value summary in this column.",
+                    "enum": [
+                        "Umb.ValueType.Section.Aliases",
+                        "Umb.ValueType.User.State",
+                        "Umb.ValueType.UserGroup.References",
+                        "Umbraco.UserPicker"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "field",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaUfmComponent": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "marker": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaUfmFilter": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "MetaUserProfileApp": {
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaValueSummary": {
+            "type": "object"
+        },
+        "MetaWorkspace": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceAction": {
+            "type": "object"
+        },
+        "MetaWorkspaceActionDefaultKind": {
+            "properties": {
+                "additionalOptions": {
+                    "type": "boolean"
+                },
+                "color": {
+                    "enum": [
+                        "",
+                        "danger",
+                        "default",
+                        "invalid",
+                        "positive",
+                        "warning"
+                    ],
+                    "type": "string"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "look": {
+                    "enum": [
+                        "",
+                        "default",
+                        "outline",
+                        "placeholder",
+                        "primary",
+                        "secondary"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "MetaWorkspaceActionMenuItem": {
+            "type": "object"
+        },
+        "MetaWorkspaceActionMenuItemDefaultKind": {
+            "properties": {
+                "icon": {
+                    "description": "An icon to represent the action to be performed",
+                    "examples": [
+                        "icon-box",
+                        "icon-grid"
+                    ],
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The friendly name of the action to perform",
+                    "examples": [
+                        "Create",
+                        "Create Content Template"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceContextMenuStructureKind": {
+            "properties": {
+                "menuItemAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "menuItemAlias"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceDefaultKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType",
+                "headline"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceInfoApp": {
+            "type": "object"
+        },
+        "MetaWorkspaceInfoAppAuditLogKind": {
+            "properties": {
+                "auditLogRepositoryAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "auditLogRepositoryAlias"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceRoutableKind": {
+            "properties": {
+                "entityType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityType"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceView": {
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewCollectionKind": {
+            "properties": {
+                "collectionAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionAlias",
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewContentTypeDesignEditorKind": {
+            "properties": {
+                "compositionRepositoryAlias": {
+                    "type": "string"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname"
+            ],
+            "type": "object"
+        },
+        "MetaWorkspaceViewTreeKind": {
+            "properties": {
+                "icon": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "pathname": {
+                    "type": "string"
+                },
+                "treeAlias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "icon",
+                "label",
+                "pathname",
+                "treeAlias"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettings": {
+            "properties": {
+                "defaultData": {
+                    "items": {
+                        "$ref": "#/definitions/PropertyEditorSettingsDefaultData"
+                    },
+                    "type": "array"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/PropertyEditorSettingsProperty"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "properties"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettingsDefaultData": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "value": {}
+            },
+            "required": [
+                "alias",
+                "value"
+            ],
+            "type": "object"
+        },
+        "PropertyEditorSettingsProperty": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "config": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "value": {}
+                        },
+                        "required": [
+                            "alias"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "propertyEditorDataSourceAlias": {
+                    "type": "string"
+                },
+                "propertyEditorUiAlias": {
+                    "type": "string"
+                },
+                "validation": {
+                    "properties": {
+                        "mandatory": {
+                            "type": "boolean"
+                        },
+                        "mandatoryMessage": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "mandatory"
+                    ],
+                    "type": "object"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "alias",
+                "label",
+                "propertyEditorUiAlias"
+            ],
+            "type": "object"
+        },
+        "SectionAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.SectionAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the section that this extension should be available in",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more workspaces that this extension should be available in",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "SwitchConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Switch%22%3E"
+                },
+                {
+                    "properties": {
+                        "frequency": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "frequency"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "TreeAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.TreeAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "The tree that this extension should be available in.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbCollectionHasItemsConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CollectionHasItems",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.CollectionAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CollectionAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Delay\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Delay",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Entity.Type\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Entity.Type",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Entity.Unique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Entity.Unique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.EntityContentType.Unique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.EntityContentType.Unique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.SectionAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.SectionAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.SectionUserPermission\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.SectionUserPermission",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.Switch\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Switch",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.TreeAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.TreeAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowChangePassword\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowChangePassword",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowDeleteAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowDeleteAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowDisableAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowDisableAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowEnableAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowEnableAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowExternalLoginAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowExternalLoginAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowMfaAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowMfaAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.User.AllowUnlockAction\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.User.AllowUnlockAction",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.UserPermission.Fallback\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.UserPermission.Fallback",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.UserPermission.Language\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.UserPermission.Language",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceContentTypeAlias\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceContentTypeAlias",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceContentTypeUnique\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceContentTypeUnique",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<\"Umb.Condition.WorkspaceEntityType\">": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceEntityType",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbConditionConfigBase<string>": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbContentWorkspaceIsLoadedConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Workspace.ContentIsLoaded",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbCurrentUserGroupIdConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CurrentUser.GroupId",
+                    "type": "string"
+                },
+                "allOf": {
+                    "description": "The user groups that the current user must be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "match": {
+                    "description": "The user group that the current user must be a member of to pass the condition.",
+                    "examples": "['guid1']",
+                    "type": "string"
+                },
+                "noneOf": {
+                    "description": "The user group(s) that the current user must not be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "oneOf": {
+                    "description": "The user group(s) that the current user must be a member of to pass the condition.",
+                    "examples": "[['guid1', 'guid2']]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbEntityContentTypeUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.EntityContentType.Unique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the unique (GUID) of the entity content type for which this extension should be available.",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more unique (GUIDs) of entity content types for which this extension should be available.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbEntityTypeConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Entity.Type%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbEntityUnique": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "UmbEntityUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.Entity.Unique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "oneOf": {
+                            "items": {
+                                "$ref": "#/definitions/UmbEntityUnique"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbFallbackUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.UserPermission.Fallback%22%3E"
+                },
+                {
+                    "properties": {
+                        "allOf": {
+                            "description": "The user must have all of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "oneOf": {
+                            "description": "The user must have at least one of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbInModalConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.InModal",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "The expected modal state to match.\n- `true`: Condition is permitted when inside a modal (default)\n- `false`: Condition is permitted when NOT inside a modal",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsAdminConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.CurrentUser.IsAdmin",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsRoutableContextConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.IsRoutableContext",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "The expected routable context state to match.\n- `true`: Condition is permitted when inside a routable context (default)\n- `false`: Condition is permitted when NOT inside a routable context",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbIsServerProductionModeConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Server.IsProductionMode",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "If true (default), the condition is permitted when in Production mode.\nIf false, the condition is permitted when NOT in Production mode.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbItemDataResolverConstructor<UmbItemModel>": {
+            "type": "object"
+        },
+        "UmbLanguageUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.UserPermission.Language%22%3E"
+                },
+                {
+                    "properties": {
+                        "allOf": {
+                            "description": "The user must have all of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "match": {
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "The user must have at least one of the permissions in this array for the condition to be met.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbLocalizationDictionary": {
+            "type": "object"
+        },
+        "UmbPropertyHasValueConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.Property.HasValue",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
+        },
+        "UmbSectionUserPermissionConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.SectionUserPermission%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceContentTypeAliasConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceContentTypeAlias%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define a content type alias in which workspace this extension should be available",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more content type aliases in which workspace this extension should be available",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceContentTypeUniqueConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceContentTypeUnique%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define a content type unique (GUID) in which workspace this extension should be available",
+                            "type": "string"
+                        },
+                        "oneOf": {
+                            "description": "Define one or more content type unique (GUIDs) in which workspace this extension should be available",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "UmbWorkspaceEntityIsNewConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceEntityIsNew",
+                    "type": "string"
+                },
+                "match": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "alias",
+                "match"
+            ],
+            "type": "object"
+        },
+        "UmbWorkspaceEntityTypeConditionConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/UmbConditionConfigBase%3C%22Umb.Condition.WorkspaceEntityType%22%3E"
+                },
+                {
+                    "properties": {
+                        "match": {
+                            "description": "Define the workspace that this extension should be available in",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "match"
+                    ],
+                    "type": "object"
+                }
+            ]
         },
         "UmbracoPackageImportmap": {
             "properties": {
@@ -46,10 +16881,38 @@
                 "type": "string"
             },
             "type": "object"
+        },
+        "WorkspaceAliasConditionConfig": {
+            "properties": {
+                "alias": {
+                    "const": "Umb.Condition.WorkspaceAlias",
+                    "type": "string"
+                },
+                "match": {
+                    "description": "Define the workspace that this extension should be available in",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Define one or more workspaces that this extension should be available in",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "alias"
+            ],
+            "type": "object"
         }
     },
     "description": "Umbraco package manifest JSON",
     "properties": {
+        "allowCacheBusting": {
+            "default": true,
+            "title": "Whether Umbraco automatically appends a cache-buster to this package's clean /App_Plugins assets (importmap and extensions)",
+            "type": "boolean"
+        },
         "allowPackageTelemetry": {
             "default": true,
             "title": "Decides if the package sends telemetry data for collection",
@@ -66,8 +16929,351 @@
             "type": "boolean"
         },
         "extensions": {
-            "$ref": "#/definitions/(ManifestUfmFilter%7CManifestUfmComponent%7CManifestMarkedExtension%7CManifestPropertyValueCloner%7CUmbPropertyEditorExtensions%7CManifestPropertyValuePreset%7CManifestPropertyValueResolver%7CManifestEntityActionDuplicateToKind%7CManifestEntityActionMoveToKind%7CManifestEntityActionReloadTreeItemChildrenKind%7CManifestEntityActionSortChildrenOfKind%7CUmbSectionExtensions%7CManifestDashboard%7CManifestWorkspaceDefaultKind%7CManifestWorkspaceActionDefaultKind%7CManifestWorkspaceFooterApp%7CManifestWorkspaceFooterAppMenuBreadcrumbKind%7CManifestWorkspaceFooterAppVariantMenuBreadcrumbKind%7CManifestWorkspaceViewContentTypeDesignEditorKind%7CManifestWorkspaceView%3CMetaWorkspaceView%3E%7CManifestWorkspaceRoutableKind%7CManifestWorkspaceContext%7CManifestTreeItem%7CManifestTree%7CManifestEntityActionCreateFolderKind%7CManifestEntityActionDeleteFolderKind%7CManifestEntityActionUpdateFolderKind%7CManifestEntityCreateOptionActionFolderKind%7CManifestMenu%7CManifestMenuItem%7CManifestMenuItemActionKind%7CManifestMenuItemLinkKind%7CManifestWorkspaceContextMenuStructureKind%7CManifestMenuItemTreeKind%7CManifestModal%7CManifestCollectionAction%7CManifestCollection%7CManifestCollectionActionCreateKind%7CManifestCollectionTextFilter%7CManifestCollectionMenu%7CManifestCollectionView%7CManifestCollectionViewTableKind%7CManifestWorkspaceViewCollectionKind%7CManifestValueSummary%7CManifestAuditLogActionDefaultKind%7CManifestEntityActionContentRollbackKind%7CManifestWorkspaceInfoAppAuditLogKind%7CManifestWorkspaceViewContentCollectionKind%7CManifestEntityActionSortChildrenOfContentKind%7CManifestUserProfileApp%7CManifestAuthProvider%7CManifestIcons%7CManifestEntityUserPermission%7CManifestGranularUserPermission%7CManifestLocalization%7CManifestPickerSearchResultItem%7CManifestCollectionMenuItem%7CManifestPropertyEditorDataSource%7CManifestEntityActionDeleteKind%7CManifestEntityActionDefaultKind%7CManifestEntityActionCreateKind%7CManifestSearchProvider%7CManifestSearchResultItem%7CManifestGlobalSearch%7CManifestAppEntryPoint%7CManifestBackofficeEntryPoint%7CManifestEntryPoint%7CUmbCoreManifestTypes%7CManifestEntityItemRef%3CMetaEntityItemRef%3E%7CManifestDataSourceDataMapping%3CMetaDataSourceDataMapping%3E%7CManifestPropertyContext%3CMetaPropertyContext%3E%7CManifestSectionContext%3CMetaSectionContext%3E%7CManifestWorkspaceActionMenuItem%3CMetaWorkspaceActionMenuItem%3E%7CManifestWorkspaceActionMenuItemDefaultKind%3CMetaWorkspaceActionMenuItemDefaultKind%3E%7CManifestWorkspaceInfoApp%3CMetaWorkspaceInfoApp%3E%7CManifestWorkspaceAction%3CMetaWorkspaceAction%2CUmbWorkspaceAction%3CMetaWorkspaceAction%3E%3E%7CManifestWorkspace%3CMetaWorkspace%2CUmbControllerHostElement%2CUmbWorkspaceContext%3E%7CManifestEntityCreateOptionAction%3CMetaEntityCreateOptionAction%3E%7CManifestEntityCollectionItemCard%3CMetaEntityCollectionItemCard%3E%7CManifestEntityCollectionItemRef%3CMetaEntityCollectionItemRef%3E%7CManifestAuditLogAction%3CMetaAuditLogAction%3E%7CManifestCurrentUserAction%3CMetaCurrentUserAction%3E%7CManifestPropertyValidationPathTranslator%3Cany%3E%7CManifestEntityAction%3CMetaEntityAction%3E%7CManifestEntityBulkActionDeleteKind%7CUmbEntityBulkActionExtensions%7CManifestExternalLoginProvider%7CManifestGlobalContext%7CManifestHeaderApp%7CManifestHeaderAppButtonKind%7CManifestMfaLoginProvider%7CManifestPreviewAppProvider%7CManifestRepository%3CUmbApi%3E%7CUmbStoreExtensions)%5B%5D",
-            "title": "An array of Umbraco package manifest types that will be installed"
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/ManifestBase"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUfmFilter"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUfmComponent"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMarkedExtension"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValueCloner"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorUi"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorSchema"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValuePreset"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValueResolver"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeAction"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDuplicateToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionMoveToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionReloadTreeItemChildrenKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionSortChildrenOfKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterAppMenuBreadcrumbKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceFooterAppVariantMenuBreadcrumbKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewContentTypeDesignEditorKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceView%3CMetaWorkspaceView%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceRoutableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceContext"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionRoute"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionSidebarApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSection"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestDashboard"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTree"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionCreateFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDeleteFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionUpdateFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCreateOptionActionFolderKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenu"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemActionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemLinkKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceContextMenuStructureKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMenuItemTreeKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeItemCard"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewTreeKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestTreeViewTableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestModal"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionAction"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollection"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionTextFilter"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionMenu"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionView"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionViewTableKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewCollectionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestValueSummary"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuditLogActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentRollbackKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceInfoAppAuditLogKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceViewContentCollectionKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionSortChildrenOfContentKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentPublishKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestUserProfileApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuthProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestIcons"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityUserPermission"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGranularUserPermission"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestLocalization"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionContentUnpublishKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPickerSearchResultItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCollectionMenuItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyEditorDataSource"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDeleteKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionDefaultKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityActionCreateKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSearchProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSearchResultItem"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGlobalSearch"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCondition"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAppEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestBackofficeEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntryPoint"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestBundle%3CUmbCoreManifestTypes%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityItemRef%3CMetaEntityItemRef%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestDataSourceDataMapping%3CMetaDataSourceDataMapping%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyContext%3CMetaPropertyContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCreateOptionAction%3CMetaEntityCreateOptionAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionMenuItem%3CMetaWorkspaceActionMenuItem%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceActionMenuItemDefaultKind%3CMetaWorkspaceActionMenuItemDefaultKind%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceInfoApp%3CMetaWorkspaceInfoApp%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspaceAction%3CMetaWorkspaceAction%2CUmbWorkspaceAction%3CMetaWorkspaceAction%3E%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestWorkspace%3CMetaWorkspace%2CUmbControllerHostElement%2CUmbWorkspaceContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestSectionContext%3CMetaSectionContext%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCollectionItemCard%3CMetaEntityCollectionItemCard%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityCollectionItemRef%3CMetaEntityCollectionItemRef%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestAuditLogAction%3CMetaAuditLogAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestCurrentUserAction%3CMetaCurrentUserAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPropertyValidationPathTranslator%3Cany%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityAction%3CMetaEntityAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDeleteKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkAction%3CMetaEntityBulkAction%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDefaultKind%3CMetaEntityBulkActionDefaultKind%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionDuplicateToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionMoveToKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestEntityBulkActionTrashKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestExternalLoginProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestGlobalContext"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestHeaderApp"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestHeaderAppButtonKind"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestMfaLoginProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestPreviewAppProvider"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestRepository%3CUmbApi%3E"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestStore"
+                    },
+                    {
+                        "$ref": "#/definitions/ManifestItemStore"
+                    }
+                ]
+            },
+            "title": "An array of Umbraco package manifest types that will be installed",
+            "type": "array"
         },
         "id": {
             "title": "The unique identifier of the Umbraco package",


### PR DESCRIPTION
- Update Umbraco.Cms and Umbraco.Cms.DevelopmentMode.Backoffice from 18.0.2 to 18.1.0
- Update Sentry.AspNetCore from 6.7.0 to 6.8.0
- Update ReverseMarkdown from 6.1.0 to 6.1.1
- Update SQLitePCLRaw.bundle_e_sqlite3 from 2.1.12 to 3.0.5
- Regenerate the tracked Umbraco appsettings and package manifest schemas
- Keep Microsoft.OpenApi at the ASP.NET Core 10-compatible 2.11.0 release