### PR TITLE
feat: promote released images through infrastructure PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,39 @@ jobs:
     with:
       version: ${{ needs.release.outputs.release-version }}
     secrets: inherit
+
+  promote-staging:
+    needs:
+      - release
+      - docker
+    if: ${{ needs.release.outputs.new-release-published == 'true' }}
+    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@main
+    with:
+      deployment-repository: sgfdevs/infra-k8s-apps
+      kustomization-path: src/k8s/apps/sgf.dev/staging
+      image: ghcr.io/sgfdevs/sgf.dev
+      image-tag: ${{ needs.release.outputs.release-version }}
+      source-ref: v${{ needs.release.outputs.release-version }}
+      promotion-id: staging
+      auto-merge: true
+      github-app-id: "4527359"
+    secrets:
+      github-app-private-key: ${{ secrets.INFRA_AUTOMATION_APP_PRIVATE_KEY }}
+
+  promote-production:
+    needs:
+      - release
+      - docker
+      - promote-staging
+    if: ${{ needs.release.outputs.new-release-published == 'true' }}
+    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@main
+    with:
+      deployment-repository: sgfdevs/infra-k8s-apps
+      kustomization-path: src/k8s/apps/sgf.dev/production
+      image: ghcr.io/sgfdevs/sgf.dev
+      image-tag: ${{ needs.release.outputs.release-version }}
+      source-ref: v${{ needs.release.outputs.release-version }}
+      promotion-id: production
+      github-app-id: "4527359"
+    secrets:
+      github-app-private-key: ${{ secrets.INFRA_AUTOMATION_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - release
       - docker
     if: ${{ needs.release.outputs.new-release-published == 'true' }}
-    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@main
+    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@v0.8.0
     with:
       deployment-repository: sgfdevs/infra-k8s-apps
       kustomization-path: src/k8s/apps/sgf.dev/staging
@@ -70,7 +70,7 @@ jobs:
       - docker
       - promote-staging
     if: ${{ needs.release.outputs.new-release-published == 'true' }}
-    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@main
+    uses: glitchedmob/infra-gha/.github/workflows/kustomize-image-pr.yml@v0.8.0
     with:
       deployment-repository: sgfdevs/infra-k8s-apps
       kustomization-path: src/k8s/apps/sgf.dev/production


### PR DESCRIPTION
This connects the `sgf.dev` release pipeline to the reusable Kustomize image promotion workflow. After a multi-architecture image is published, it opens the staging PR first and then opens production as soon as staging PR creation succeeds.

- Pins the reusable workflow to `glitchedmob/infra-gha@v0.8.0`.
- Enables auto-merge for the `staging` overlay only.
- Leaves the `production` overlay for manual review and merge.
- Uses GitHub App `4527359`, with only `INFRA_AUTOMATION_APP_PRIVATE_KEY` stored as a secret.