### PR TITLE
perf: optimize Docker build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@
 **/.env
 **/.git
 **/.gitignore
+**/.github
+**/.opencode
 **/.project
 **/.settings
 **/.toolstarget
@@ -23,10 +25,9 @@
 **/values.dev.yaml
 LICENSE
 README.md
+SgfDevs.Tests
+SgfDevs.slnx
 SgfDevs/Umbraco/Logs
 SgfDevs/Umbraco/Data
-!**/.gitignore
-!.git/HEAD
-!.git/config
-!.git/packed-refs
-!.git/refs/heads/**
+caddy
+scripts

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,8 +55,8 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline
           platforms: ${{ matrix.platform }}
           provenance: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-RUN mkdir -p /usr/src/main
 WORKDIR /usr/src/main
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
-RUN mkdir -p /src
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
 WORKDIR /src
-COPY "./SgfDevs/SgfDevs.csproj" "./SgfDevs/SgfDevs.csproj"
-RUN dotnet restore "./SgfDevs/SgfDevs.csproj"
-COPY . .
-RUN dotnet build "./SgfDevs/SgfDevs.csproj" -c Release -o /usr/src/main/build
-
-FROM build AS publish
-RUN dotnet publish "./SgfDevs/SgfDevs.csproj" -c Release -o /usr/src/main/publish
+COPY SgfDevs/SgfDevs.csproj SgfDevs/
+RUN dotnet restore SgfDevs/SgfDevs.csproj
+COPY SgfDevs/ SgfDevs/
+RUN dotnet publish SgfDevs/SgfDevs.csproj -c Release --no-restore -o /app/publish
 
 FROM base AS final
 ENV ASPNETCORE_HTTP_PORTS=80
 WORKDIR /usr/src/main
-COPY --from=publish /usr/src/main/publish .
+COPY --from=publish /app/publish .
 RUN mkdir -p umbraco/Data && touch umbraco/Data/Umbraco.sqlite.db
 ENTRYPOINT ["dotnet", "SgfDevs.dll"]


### PR DESCRIPTION
Reduces Docker publishing overhead by avoiding transfer of the oversized GHA intermediate-layer cache while preserving reusable image-layer caching.

- import inline cache metadata from the latest published image
- publish cache metadata with each platform image
- remove the redundant build before publish
- limit the build context to application source
