### PR TITLE
perf: reduce Docker runtime image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN dotnet publish SgfDevs/SgfDevs.csproj -c Release --no-restore --arch $TARGET
     && touch /app/publish/umbraco/Data/Umbraco.sqlite.db
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra AS final
-ENV ASPNETCORE_HTTP_PORTS=80
+ENV ASPNETCORE_HTTP_PORTS=8080
 WORKDIR /usr/src/main
 COPY --from=publish --chown=$APP_UID:$APP_UID /app/publish .
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["dotnet", "SgfDevs.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-WORKDIR /usr/src/main
-EXPOSE 80
-
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
+ARG TARGETARCH
 WORKDIR /src
 COPY SgfDevs/SgfDevs.csproj SgfDevs/
-RUN dotnet restore SgfDevs/SgfDevs.csproj
+RUN dotnet restore SgfDevs/SgfDevs.csproj --arch $TARGETARCH
 COPY SgfDevs/ SgfDevs/
-RUN dotnet publish SgfDevs/SgfDevs.csproj -c Release --no-restore -o /app/publish
+RUN dotnet publish SgfDevs/SgfDevs.csproj -c Release --no-restore --arch $TARGETARCH --self-contained false -o /app/publish \
+    && mkdir -p \
+        /app/publish/umbraco/Data \
+        /app/publish/umbraco/Logs \
+        /app/publish/umbraco/TEMP/MediaCache \
+    && touch /app/publish/umbraco/Data/Umbraco.sqlite.db
 
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra AS final
 ENV ASPNETCORE_HTTP_PORTS=80
 WORKDIR /usr/src/main
-COPY --from=publish /app/publish .
-RUN mkdir -p umbraco/Data && touch umbraco/Data/Umbraco.sqlite.db
+COPY --from=publish --chown=$APP_UID:$APP_UID /app/publish .
+EXPOSE 80
 ENTRYPOINT ["dotnet", "SgfDevs.dll"]

--- a/caddy/Development/Caddyfile
+++ b/caddy/Development/Caddyfile
@@ -1,3 +1,3 @@
 http://localhost {
-	reverse_proxy sgf-devs:80
+	reverse_proxy sgf-devs:8080
 }

--- a/caddy/Production/Caddyfile
+++ b/caddy/Production/Caddyfile
@@ -1,5 +1,5 @@
 http://www.sgf.dev {
-	reverse_proxy sgf-devs:80
+	reverse_proxy sgf-devs:8080
 }
 
 sgf.dev {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - './SgfDevs/umbraco/Data/Umbraco.sqlite.db:/usr/src/main/umbraco/Data/Umbraco.sqlite.db'
       - 'media-cache:/usr/src/main/umbraco/TEMP/MediaCache'
-      - 'data-protection-keys:/root/.aspnet/DataProtection-Keys'
+      - 'data-protection-keys:/home/app/.aspnet/DataProtection-Keys'
     restart: unless-stopped
   proxy:
     image: caddy:2.11


### PR DESCRIPTION
Reduces the runtime image size by using Microsoft's chiseled ASP.NET image and publishing only the native assets required by each target architecture.

- select the publish architecture from Docker's automatic `TARGETARCH` argument
- keep the deployment framework-dependent while pruning unrelated native assets
- run the final image as the chiseled image's non-root UID 1654
- serve on unprivileged port 8080 and update local Caddy upstreams
- prepare writable Umbraco directories before entering the shell-less runtime stage
- persist local data-protection keys under the non-root user's home directory