### PR TITLE
feat: configure explicit Umbraco server roles

### DIFF
--- a/SgfDevs/Dev/FixedServerRoleAccessor.cs
+++ b/SgfDevs/Dev/FixedServerRoleAccessor.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Core.Sync;
+
+namespace SgfDevs.Dev;
+
+internal sealed class FixedServerRoleAccessor(ServerRole serverRole) : IServerRoleAccessor
+{
+    public ServerRole CurrentServerRole { get; } = serverRole;
+}

--- a/SgfDevs/Program.cs
+++ b/SgfDevs/Program.cs
@@ -17,6 +17,8 @@ using SgfDevs.Dev.EventSync.Sessionize;
 using SgfDevs.HealthChecks;
 using SGFDevs.Dev;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.DependencyInjection;
 using Umbraco.Cms.Persistence.Sqlite;
 using Umbraco.Extensions;
 
@@ -47,6 +49,17 @@ else
     });
 }
 
+var serverRoleName = builder.Configuration["SGFDevs:ServerRole"] ?? nameof(ServerRole.Single);
+if (!Enum.TryParse(serverRoleName, false, out ServerRole serverRole) ||
+    serverRole is ServerRole.Unknown ||
+    !Enum.IsDefined(serverRole))
+{
+    throw new InvalidOperationException(
+        $"Unsupported SGFDevs:ServerRole value '{serverRoleName}'. " +
+        $"Expected {nameof(ServerRole.Single)}, {nameof(ServerRole.SchedulingPublisher)}, or {nameof(ServerRole.Subscriber)}.");
+}
+
+umbracoBuilder.SetServerRegistrar(new FixedServerRoleAccessor(serverRole));
 umbracoBuilder.Build();
 
 builder.Services.AddHealthChecks()


### PR DESCRIPTION
Adds configuration-driven Umbraco server roles so the deployment can designate a scheduling publisher and subscriber while preserving single-server behavior by default.

- Read `SGFDevs:ServerRole` and default to `Single` when it is not configured.
- Register a fixed `IServerRoleAccessor` before Umbraco builds its service container.
- Reject unknown or invalid role values during startup.