### PR TITLE
feat: configure media CDN URL provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ Umbraco__CMS__Global__Smtp__Port=
 Umbraco__CMS__Global__Smtp__Username=
 Umbraco__CMS__Global__Smtp__Password=
 Umbraco__CMS__Global__Smtp__SecureSocketOptions=StartTls
+Umbraco__Storage__Cdn__Url=
 Sentry__Dsn=
 CADDY_ENVIRONMENT=Development
 HTTP_PORT=80

--- a/SgfDevs/Program.cs
+++ b/SgfDevs/Program.cs
@@ -33,20 +33,18 @@ var umbracoBuilder = builder.CreateUmbracoBuilder()
     .AddComposers();
 
 var blobStorageKey = builder.Configuration["SGFDevs:AzureBlobStorageKey"];
-if (string.IsNullOrEmpty(blobStorageKey))
-{
-    umbracoBuilder.AddCdnMediaUrlProvider(options =>
-    {
-        options.Url = new Uri("https://sgf.dev/media/");
-    });
-}
-else
+if (!string.IsNullOrEmpty(blobStorageKey))
 {
     umbracoBuilder.AddAzureBlobMediaFileSystem(options =>
     {
         options.ConnectionString = $"DefaultEndpointsProtocol=https;AccountName=sgfdevs;AccountKey={blobStorageKey};EndpointSuffix=core.windows.net";
         options.ContainerName = "website";
     });
+}
+
+if (!string.IsNullOrEmpty(builder.Configuration["Umbraco:Storage:Cdn:Url"]))
+{
+    umbracoBuilder.AddCdnMediaUrlProvider();
 }
 
 var serverRoleName = builder.Configuration["SGFDevs:ServerRole"] ?? nameof(ServerRole.Single);


### PR DESCRIPTION
Configure Umbraco media CDN URLs independently from the media storage provider so remote storage and CDN delivery can be enabled together.

- Keep Azure Blob media storage enabled when its key is configured
- Register the CDN URL provider when `Umbraco:Storage:Cdn:Url` is configured
- Document the CDN URL environment variable