### PR TITLE
fix: avoid redundant speaker image saves

### DIFF
--- a/SgfDevs.Tests/SessionizeSpeakerMediaServiceTests.cs
+++ b/SgfDevs.Tests/SessionizeSpeakerMediaServiceTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text;
+using SgfDevs.Dev.EventSync;
+using Xunit;
+
+namespace SgfDevs.Tests;
+
+public class SessionizeSpeakerMediaServiceTests
+{
+    [Fact]
+    public void StreamsHaveEqualContent_ReturnsTrueForIdenticalContent()
+    {
+        using var first = CreateStream("same image");
+        using var second = CreateStream("same image");
+
+        var result = SessionizeSpeakerMediaService.StreamsHaveEqualContent(first, second);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void StreamsHaveEqualContent_ReturnsFalseForDifferentContent()
+    {
+        using var first = CreateStream("first image");
+        using var second = CreateStream("second image");
+
+        var result = SessionizeSpeakerMediaService.StreamsHaveEqualContent(first, second);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void StreamsHaveEqualContent_RestoresFirstStreamPosition()
+    {
+        using var first = CreateStream("same image");
+        using var second = CreateStream("same image");
+        first.Position = 2;
+        second.Position = 4;
+
+        var result = SessionizeSpeakerMediaService.StreamsHaveEqualContent(first, second);
+
+        Assert.True(result);
+        Assert.Equal(2, first.Position);
+        Assert.Equal(4, second.Position);
+    }
+
+    private static MemoryStream CreateStream(string content) => new(Encoding.UTF8.GetBytes(content));
+}

--- a/SgfDevs/Dev/EventSync/SessionizeSpeakerMediaService.cs
+++ b/SgfDevs/Dev/EventSync/SessionizeSpeakerMediaService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -67,6 +68,30 @@ public class SessionizeSpeakerMediaService
 
             var importedSpeakersFolder = GetOrCreateImportedSpeakersFolder();
             var media = GetOrCreateSpeakerImage(importedSpeakersFolder.Id, presenter);
+            var profileImageUdi = new GuidUdi(Constants.UdiEntityType.Media, media.Key).ToString();
+
+            if (media.HasIdentity)
+            {
+                try
+                {
+                    using var existingStream = _mediaFileManager.GetFile(media, out _);
+                    if (ReferenceEquals(existingStream, Stream.Null) == false &&
+                        StreamsHaveEqualContent(stream, existingStream))
+                    {
+                        return presenter with { ProfileImageUdi = profileImageUdi };
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(
+                        exception,
+                        "Failed to compare the existing Sessionize speaker image for {SpeakerName} ({SpeakerId}); retaining it.",
+                        presenter.Name,
+                        presenter.SessionizeSpeakerId);
+                    return presenter with { ProfileImageUdi = profileImageUdi };
+                }
+            }
+
             var fileName = BuildFileName(presenter);
 
             media.SetValue(
@@ -82,7 +107,7 @@ public class SessionizeSpeakerMediaService
 
             return presenter with
             {
-                ProfileImageUdi = new GuidUdi(Constants.UdiEntityType.Media, media.Key).ToString()
+                ProfileImageUdi = profileImageUdi
             };
         }
         catch (Exception exception)
@@ -177,5 +202,40 @@ public class SessionizeSpeakerMediaService
             : presenter.SessionizeSpeakerId;
 
         return $"{baseName}{extension}";
+    }
+
+    internal static bool StreamsHaveEqualContent(Stream first, Stream second)
+    {
+        var firstPosition = first.CanSeek ? first.Position : 0;
+        var secondPosition = second.CanSeek ? second.Position : 0;
+
+        try
+        {
+            if (first.CanSeek)
+            {
+                first.Position = 0;
+            }
+
+            if (second.CanSeek)
+            {
+                second.Position = 0;
+            }
+
+            var firstHash = SHA256.HashData(first);
+            var secondHash = SHA256.HashData(second);
+            return firstHash.AsSpan().SequenceEqual(secondHash);
+        }
+        finally
+        {
+            if (first.CanSeek)
+            {
+                first.Position = firstPosition;
+            }
+
+            if (second.CanSeek)
+            {
+                second.Position = secondPosition;
+            }
+        }
     }
 }


### PR DESCRIPTION
Prevents unchanged Sessionize speaker images from receiving new cache-busting URLs on every synchronization.

- Compare downloaded and existing Azure-backed media using SHA-256.
- Skip the Umbraco media save when image bytes are unchanged.
- Retain existing media when comparison fails.
- Cover identical, changed, and seeked streams with tests.