### PR TITLE
chore: update .NET packages

### DIFF
--- a/SgfDevs.Tests/appsettings-schema.usync.json
+++ b/SgfDevs.Tests/appsettings-schema.usync.json
@@ -159,6 +159,11 @@
           "description": "Should folder keys be cached (for speed)",
           "default": true
         },
+        "CacheImportState": {
+          "type": "boolean",
+          "description": "Cache the results of the \"no change\" checks between runs, so repeat imports can skip\nunchanged items without a database lookup or a re-serialize.",
+          "default": false
+        },
         "ShowVersionCheckWarning": {
           "type": "boolean",
           "description": "Show a version check warning to the user if the folder version is less than the version expected by uSync.",

--- a/SgfDevs/SgfDevs.csproj
+++ b/SgfDevs/SgfDevs.csproj
@@ -5,16 +5,16 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="16.2.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
-    <PackageReference Include="ReverseMarkdown" Version="6.1.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.8.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="ReverseMarkdown" Version="6.2.1" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" NoWarn="NU1510" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" NoWarn="NU1510" />
     <PackageReference Include="Umbraco.Cms" Version="18.1.1" />
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.1.1" />
     <PackageReference Include="Umbraco.StorageProviders.AzureBlob" Version="18.0.0" />
-    <PackageReference Include="uSync" Version="18.0.3" />
+    <PackageReference Include="uSync" Version="18.1.1" />
     <PackageReference Include="Skybrud.Umbraco.Redirects" Version="18.0.0-alpha001" />
   </ItemGroup>
   <!-- Force Windows to use ICU. Otherwise Windows 10 2019H1+ will do it, but older Windows 10 and most, if not all, Windows Server editions will run NLS -->

--- a/SgfDevs/SgfDevs.csproj
+++ b/SgfDevs/SgfDevs.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" NoWarn="NU1510" />
-    <PackageReference Include="Umbraco.Cms" Version="18.1.0" />
-    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.1.0" />
+    <PackageReference Include="Umbraco.Cms" Version="18.1.1" />
+    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.1.1" />
     <PackageReference Include="Umbraco.StorageProviders.AzureBlob" Version="18.0.0" />
     <PackageReference Include="uSync" Version="18.0.3" />
     <PackageReference Include="Skybrud.Umbraco.Redirects" Version="18.0.0-alpha001" />

--- a/SgfDevs/appsettings-schema.usync.json
+++ b/SgfDevs/appsettings-schema.usync.json
@@ -159,6 +159,11 @@
           "description": "Should folder keys be cached (for speed)",
           "default": true
         },
+        "CacheImportState": {
+          "type": "boolean",
+          "description": "Cache the results of the \"no change\" checks between runs, so repeat imports can skip\nunchanged items without a database lookup or a re-serialize.",
+          "default": false
+        },
         "ShowVersionCheckWarning": {
           "type": "boolean",
           "description": "Show a version check warning to the user if the folder version is less than the version expected by uSync.",


### PR DESCRIPTION
Updates Umbraco, uSync, ReverseMarkdown, Sentry, System.Security.Cryptography.Xml, and Microsoft.OpenApi. Microsoft.OpenApi stays on the ASP.NET Core 10-compatible 2.x line because 3.x breaks the OpenAPI source generator.