### PR TITLE
fix: pin compatible changelog preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - run: npm install -g semantic-release conventional-changelog-conventionalcommits @semantic-release/exec
+      - run: npm install -g semantic-release conventional-changelog-conventionalcommits@10.3.0 @semantic-release/exec
 
       - name: Create Release
         id: semantic


### PR DESCRIPTION
Pins the conventional commits preset to the last version compatible with semantic-release's current changelog writer. This restores release-note generation while the upstream packages are out of sync.