### PR TITLE
fix: lazy load directory images

### DIFF
--- a/SgfDevs/Views/Directory.cshtml
+++ b/SgfDevs/Views/Directory.cshtml
@@ -105,7 +105,7 @@
             <div class="card company_card" v-for="(member, index) in results">
                 <figure>
                     <a :href="member.url">
-                        <img :src="member.image" alt="">
+                        <img :src="member.image" :alt="member.name + ' Profile Image'" loading="lazy">
                     </a>
                     <figcaption>
                         <div v-for="tag in member.tags" :key="tag">{{ tag }}</div>


### PR DESCRIPTION
Lazy-load directory profile images to avoid sending the entire member image set to ImageSharp at once.